### PR TITLE
Bring up to equivalent quality as Python images

### DIFF
--- a/2/Dockerfile
+++ b/2/Dockerfile
@@ -9,13 +9,24 @@ ENV LANG C.UTF-8
 
 ENV PYPY_VERSION 5.4.0
 
-RUN set -x \
-	&& curl -SL "https://bitbucket.org/pypy/pypy/downloads/pypy2-v${PYPY_VERSION}-linux64.tar.bz2" \
-		| tar -xjC /usr/local --strip-components=1
-
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 8.1.2
-RUN curl -SL 'https://bootstrap.pypa.io/get-pip.py' | pypy \
-	&& pip install --upgrade pip==$PYTHON_PIP_VERSION
+
+RUN set -x \
+	&& curl -SL "https://bitbucket.org/pypy/pypy/downloads/pypy2-v${PYPY_VERSION}-linux64.tar.bz2" \
+		| tar -xjC /usr/local --strip-components=1 \
+	\
+		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
+		&& pypy /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \
+		&& rm /tmp/get-pip.py \
+# we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
+# ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
+# https://github.com/docker-library/python/pull/143#issuecomment-241032683
+	&& pip install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+# then we use "pip list" to ensure we don't have more than one pip version installed
+# https://github.com/docker-library/python/pull/100
+	&& [ "$(pip list |tac|tac| awk -F '[ ()]+' '$1 == "pip" { print $2; exit }')" = "$PYTHON_PIP_VERSION" ] \
+	\
+	&& rm -rf ~/.cache
 
 CMD ["pypy"]

--- a/2/Dockerfile
+++ b/2/Dockerfile
@@ -12,8 +12,8 @@ ENV PYPY_VERSION 5.4.0
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 8.1.2
 
-RUN set -x \
-	&& curl -SL "https://bitbucket.org/pypy/pypy/downloads/pypy2-v${PYPY_VERSION}-linux64.tar.bz2" \
+RUN set -ex \
+	&& wget -O- "https://bitbucket.org/pypy/pypy/downloads/pypy2-v${PYPY_VERSION}-linux64.tar.bz2" \
 		| tar -xjC /usr/local --strip-components=1 \
 	\
 		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \

--- a/2/Dockerfile
+++ b/2/Dockerfile
@@ -14,13 +14,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PYPY_VERSION 5.4.0
+ENV PYPY_SHA256SUM bdfea513d59dcd580970cb6f79f3a250d00191fd46b68133d5327e924ca845f8
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 8.1.2
 
 RUN set -ex \
-	&& wget -O- "https://bitbucket.org/pypy/pypy/downloads/pypy2-v${PYPY_VERSION}-linux64.tar.bz2" \
-		| tar -xjC /usr/local --strip-components=1 \
+	&& wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy2-v${PYPY_VERSION}-linux64.tar.bz2" \
+	&& echo "$PYPY_SHA256SUM  pypy.tar.bz2" | sha256sum -c \
+	&& tar -xjC /usr/local --strip-components=1 -f pypy.tar.bz2 \
+	&& rm pypy.tar.bz2 \
 	\
 		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
 		&& pypy /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \

--- a/2/Dockerfile
+++ b/2/Dockerfile
@@ -1,7 +1,7 @@
 FROM buildpack-deps:jessie
 
-# remove several traces of debian python
-RUN apt-get purge -y python.*
+# ensure local pypy is preferred over distribution python
+ENV PATH /usr/local/bin:$PATH
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.

--- a/2/Dockerfile
+++ b/2/Dockerfile
@@ -7,6 +7,12 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
+# runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		tcl \
+		tk \
+	&& rm -rf /var/lib/apt/lists/*
+
 ENV PYPY_VERSION 5.4.0
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/2/slim/Dockerfile
+++ b/2/slim/Dockerfile
@@ -10,6 +10,7 @@ ENV LANG C.UTF-8
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \
 		libexpat1 \
+		libffi6 \
 		libsqlite3-0 \
 	&& rm -rf /var/lib/apt/lists/*
 

--- a/2/slim/Dockerfile
+++ b/2/slim/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PYPY_VERSION 5.4.0
+
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 8.1.2
 
@@ -21,8 +22,19 @@ RUN set -x \
 	&& apt-get update && apt-get install -y bzip2 curl --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& curl -SL "https://bitbucket.org/pypy/pypy/downloads/pypy2-v${PYPY_VERSION}-linux64.tar.bz2" \
 		| tar -xjC /usr/local --strip-components=1 \
-	&& curl -SL 'https://bootstrap.pypa.io/get-pip.py' | pypy \
-	&& pip install --upgrade pip==$PYTHON_PIP_VERSION \
-	&& apt-get purge -y --auto-remove bzip2 curl
+	\
+		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
+		&& pypy /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \
+		&& rm /tmp/get-pip.py \
+# we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
+# ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
+# https://github.com/docker-library/python/pull/143#issuecomment-241032683
+	&& pip install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+# then we use "pip list" to ensure we don't have more than one pip version installed
+# https://github.com/docker-library/python/pull/100
+	&& [ "$(pip list |tac|tac| awk -F '[ ()]+' '$1 == "pip" { print $2; exit }')" = "$PYTHON_PIP_VERSION" ] \
+	\
+	&& apt-get purge -y --auto-remove bzip2 curl \
+	&& rm -rf ~/.cache
 
 CMD ["pypy"]

--- a/2/slim/Dockerfile
+++ b/2/slim/Dockerfile
@@ -18,9 +18,14 @@ ENV PYPY_VERSION 5.4.0
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 8.1.2
 
-RUN set -x \
-	&& apt-get update && apt-get install -y bzip2 curl --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-	&& curl -SL "https://bitbucket.org/pypy/pypy/downloads/pypy2-v${PYPY_VERSION}-linux64.tar.bz2" \
+RUN set -ex \
+	&& fetchDeps=' \
+		bzip2 \
+		wget \
+	' \
+	&& apt-get update && apt-get install -y $fetchDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+	\
+	&& wget -O- "https://bitbucket.org/pypy/pypy/downloads/pypy2-v${PYPY_VERSION}-linux64.tar.bz2" \
 		| tar -xjC /usr/local --strip-components=1 \
 	\
 		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
@@ -34,7 +39,7 @@ RUN set -x \
 # https://github.com/docker-library/python/pull/100
 	&& [ "$(pip list |tac|tac| awk -F '[ ()]+' '$1 == "pip" { print $2; exit }')" = "$PYTHON_PIP_VERSION" ] \
 	\
-	&& apt-get purge -y --auto-remove bzip2 curl \
+	&& apt-get purge -y --auto-remove $fetchDeps \
 	&& rm -rf ~/.cache
 
 CMD ["pypy"]

--- a/2/slim/Dockerfile
+++ b/2/slim/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 
-# remove several traces of debian python
-RUN apt-get purge -y python.*
+# ensure local pypy is preferred over distribution python
+ENV PATH /usr/local/bin:$PATH
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.

--- a/2/slim/Dockerfile
+++ b/2/slim/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PYPY_VERSION 5.4.0
+ENV PYPY_SHA256SUM bdfea513d59dcd580970cb6f79f3a250d00191fd46b68133d5327e924ca845f8
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 8.1.2
@@ -26,8 +27,10 @@ RUN set -ex \
 	' \
 	&& apt-get update && apt-get install -y $fetchDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	\
-	&& wget -O- "https://bitbucket.org/pypy/pypy/downloads/pypy2-v${PYPY_VERSION}-linux64.tar.bz2" \
-		| tar -xjC /usr/local --strip-components=1 \
+	&& wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy2-v${PYPY_VERSION}-linux64.tar.bz2" \
+	&& echo "$PYPY_SHA256SUM  pypy.tar.bz2" | sha256sum -c \
+	&& tar -xjC /usr/local --strip-components=1 -f pypy.tar.bz2 \
+	&& rm pypy.tar.bz2 \
 	\
 		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
 		&& pypy /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \

--- a/3/Dockerfile
+++ b/3/Dockerfile
@@ -12,8 +12,8 @@ ENV PYPY_VERSION 5.2.0-alpha1
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 8.1.2
 
-RUN set -x \
-	&& curl -SL "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v${PYPY_VERSION}-linux64.tar.bz2" \
+RUN set -ex \
+	&& wget -O- "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v${PYPY_VERSION}-linux64.tar.bz2" \
 		| tar -xjC /usr/local --strip-components=1 \
 	\
 # explicit path to "pip3" to ensure distribution-provided "pip3" cannot interfere

--- a/3/Dockerfile
+++ b/3/Dockerfile
@@ -7,6 +7,12 @@ ENV PATH /usr/local/bin:$PATH
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
+# runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		tcl \
+		tk \
+	&& rm -rf /var/lib/apt/lists/*
+
 ENV PYPY_VERSION 5.2.0-alpha1
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"

--- a/3/Dockerfile
+++ b/3/Dockerfile
@@ -14,13 +14,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PYPY_VERSION 5.2.0-alpha1
+ENV PYPY_SHA256SUM f5e66ab24267d6ddf662d07c512d06c10ebc732ae62093dabbd775ac63b9060a
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 8.1.2
 
 RUN set -ex \
-	&& wget -O- "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v${PYPY_VERSION}-linux64.tar.bz2" \
-		| tar -xjC /usr/local --strip-components=1 \
+	&& wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v${PYPY_VERSION}-linux64.tar.bz2" \
+	&& echo "$PYPY_SHA256SUM  pypy.tar.bz2" | sha256sum -c \
+	&& tar -xjC /usr/local --strip-components=1 -f pypy.tar.bz2 \
+	&& rm pypy.tar.bz2 \
 	\
 # explicit path to "pip3" to ensure distribution-provided "pip3" cannot interfere
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \

--- a/3/Dockerfile
+++ b/3/Dockerfile
@@ -1,7 +1,7 @@
 FROM buildpack-deps:jessie
 
-# remove several traces of debian python
-RUN apt-get purge -y python.*
+# ensure local pypy is preferred over distribution python
+ENV PATH /usr/local/bin:$PATH
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.

--- a/3/Dockerfile
+++ b/3/Dockerfile
@@ -9,13 +9,27 @@ ENV LANG C.UTF-8
 
 ENV PYPY_VERSION 5.2.0-alpha1
 
-RUN set -x \
-	&& curl -SL "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v${PYPY_VERSION}-linux64.tar.bz2" \
-		| tar -xjC /usr/local --strip-components=1
-
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 8.1.2
-RUN curl -SL 'https://bootstrap.pypa.io/get-pip.py' | pypy3 \
-	&& pip install --upgrade pip==$PYTHON_PIP_VERSION
+
+RUN set -x \
+	&& curl -SL "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v${PYPY_VERSION}-linux64.tar.bz2" \
+		| tar -xjC /usr/local --strip-components=1 \
+	\
+# explicit path to "pip3" to ensure distribution-provided "pip3" cannot interfere
+	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
+		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
+		&& pypy3 /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \
+		&& rm /tmp/get-pip.py \
+	; fi \
+# we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
+# ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
+# https://github.com/docker-library/python/pull/143#issuecomment-241032683
+	&& pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+# then we use "pip list" to ensure we don't have more than one pip version installed
+# https://github.com/docker-library/python/pull/100
+	&& [ "$(pip list |tac|tac| awk -F '[ ()]+' '$1 == "pip" { print $2; exit }')" = "$PYTHON_PIP_VERSION" ] \
+	\
+	&& rm -rf ~/.cache
 
 CMD ["pypy3"]

--- a/3/slim/Dockerfile
+++ b/3/slim/Dockerfile
@@ -10,6 +10,7 @@ ENV LANG C.UTF-8
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \
 		libexpat1 \
+		libffi6 \
 		libsqlite3-0 \
 	&& rm -rf /var/lib/apt/lists/*
 

--- a/3/slim/Dockerfile
+++ b/3/slim/Dockerfile
@@ -14,15 +14,30 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PYPY_VERSION 5.2.0-alpha1
+
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 8.1.2
 
 RUN set -x \
-	&& apt-get update && apt-get install -y bzip2 curl --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+	&& apt-get update && apt-get install -y bzip2 curl wget --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& curl -SL "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v${PYPY_VERSION}-linux64.tar.bz2" \
 		| tar -xjC /usr/local --strip-components=1 \
-	&& curl -SL 'https://bootstrap.pypa.io/get-pip.py' | pypy3 \
-	&& pip install --upgrade pip==$PYTHON_PIP_VERSION \
-	&& apt-get purge -y --auto-remove bzip2 curl
+	\
+# explicit path to "pip3" to ensure distribution-provided "pip3" cannot interfere
+	&& if [ ! -e /usr/local/bin/pip3 ]; then : \
+		&& wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
+		&& pypy3 /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \
+		&& rm /tmp/get-pip.py \
+	; fi \
+# we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
+# ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.6/site-packages")
+# https://github.com/docker-library/python/pull/143#issuecomment-241032683
+	&& pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
+# then we use "pip list" to ensure we don't have more than one pip version installed
+# https://github.com/docker-library/python/pull/100
+	&& [ "$(pip list |tac|tac| awk -F '[ ()]+' '$1 == "pip" { print $2; exit }')" = "$PYTHON_PIP_VERSION" ] \
+	\
+	&& apt-get purge -y --auto-remove bzip2 curl wget \
+	&& rm -rf ~/.cache
 
 CMD ["pypy3"]

--- a/3/slim/Dockerfile
+++ b/3/slim/Dockerfile
@@ -18,9 +18,14 @@ ENV PYPY_VERSION 5.2.0-alpha1
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 8.1.2
 
-RUN set -x \
-	&& apt-get update && apt-get install -y bzip2 curl wget --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-	&& curl -SL "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v${PYPY_VERSION}-linux64.tar.bz2" \
+RUN set -ex \
+	&& fetchDeps=' \
+		bzip2 \
+		wget \
+	' \
+	&& apt-get update && apt-get install -y $fetchDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+	\
+	&& wget -O- "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v${PYPY_VERSION}-linux64.tar.bz2" \
 		| tar -xjC /usr/local --strip-components=1 \
 	\
 # explicit path to "pip3" to ensure distribution-provided "pip3" cannot interfere
@@ -37,7 +42,7 @@ RUN set -x \
 # https://github.com/docker-library/python/pull/100
 	&& [ "$(pip list |tac|tac| awk -F '[ ()]+' '$1 == "pip" { print $2; exit }')" = "$PYTHON_PIP_VERSION" ] \
 	\
-	&& apt-get purge -y --auto-remove bzip2 curl wget \
+	&& apt-get purge -y --auto-remove $fetchDeps \
 	&& rm -rf ~/.cache
 
 CMD ["pypy3"]

--- a/3/slim/Dockerfile
+++ b/3/slim/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 
-# remove several traces of debian python
-RUN apt-get purge -y python.*
+# ensure local pypy is preferred over distribution python
+ENV PATH /usr/local/bin:$PATH
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.

--- a/3/slim/Dockerfile
+++ b/3/slim/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PYPY_VERSION 5.2.0-alpha1
+ENV PYPY_SHA256SUM f5e66ab24267d6ddf662d07c512d06c10ebc732ae62093dabbd775ac63b9060a
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 8.1.2
@@ -26,8 +27,10 @@ RUN set -ex \
 	' \
 	&& apt-get update && apt-get install -y $fetchDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	\
-	&& wget -O- "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v${PYPY_VERSION}-linux64.tar.bz2" \
-		| tar -xjC /usr/local --strip-components=1 \
+	&& wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v${PYPY_VERSION}-linux64.tar.bz2" \
+	&& echo "$PYPY_SHA256SUM  pypy.tar.bz2" | sha256sum -c \
+	&& tar -xjC /usr/local --strip-components=1 -f pypy.tar.bz2 \
+	&& rm pypy.tar.bz2 \
 	\
 # explicit path to "pip3" to ensure distribution-provided "pip3" cannot interfere
 	&& if [ ! -e /usr/local/bin/pip3 ]; then : \

--- a/update.sh
+++ b/update.sh
@@ -21,10 +21,19 @@ for version in "${versions[@]}"; do
 	# <td class="name"><a class="execute" href="/pypy/pypy/downloads/pypy3-2.4.0-linux64.tar.bz2">pypy3-2.4.0-linux64.tar.bz2</a></td>
 	fullVersion="$(curl -sSL 'https://bitbucket.org/pypy/pypy/downloads' | grep -E "$pypy"'-v([0-9.]+(-alpha[0-9]*)?)-linux64.tar.bz2' | sed -r 's/^.*'"$pypy"'-v([0-9.]+(-alpha[0-9]*)?)-linux64.tar.bz2.*$/\1/' | sort -V | tail -1)"
 
+	# <p>pypy2.7-5.4.0 sha256:</p>
+	# <pre class="literal-block">
+	# ...
+	# bdfea513d59dcd580970cb6f79f3a250d00191fd46b68133d5327e924ca845f8  pypy2-v5.4.0-linux64.tar.bz2
+	# ...
+	# </pre>
+	sha256sum="$(curl -sSL 'http://pypy.org/download.html' | grep -m1 -E '[a-f0-9]{64}  '"$pypy-v$fullVersion"'-linux64.tar.bz2' | cut -d' ' -f1)"
+
 	(
 		set -x
 		sed -ri '
 			s/^(ENV PYPY_VERSION) .*/\1 '"$fullVersion"'/;
+			s/^(ENV PYPY_SHA256SUM) .*/\1 '"$sha256sum"'/;
 			s/^(ENV PYTHON_PIP_VERSION) .*/\1 '"$pipVersion"'/;
 		' "$version"{,/slim}/Dockerfile
 		sed -ri 's/^(FROM pypy):.*/\1:'"$version"'/' "$version/onbuild/Dockerfile"


### PR DESCRIPTION
Ports over roughly the following PRs:
* docker-library/python#121
* docker-library/python#127
* docker-library/python#137
* docker-library/python#139
* docker-library/python#144

Also adds SHA256 checksum checks for the PyPy tarball downloads.

Apologies that this is kind of big but I'm keen that this stuff doesn't get left behind.