### PR TITLE
Remove all traces of onbuild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,12 @@ install:
 
 before_script:
   - env | sort
-  - cd "$VERSION"
-  - image="$(awk '$1 == "FROM" { print $2; exit }' onbuild/Dockerfile)${VARIANT:+-$VARIANT}"
+  - cd "$VERSION/$VARIANT"
+  - image="pypy:$VERSION${VARIANT:+-$VARIANT}"
 
 script:
-  - travis_retry docker build -t "$image" "${VARIANT:-.}"
+  - travis_retry docker build -t "$image" .
   - ~/official-images/test/run.sh "$image"
-# the "onbuild" variant has to happen with the base variant because it's FROM it
-  - true && [ "$VARIANT" ] || travis_retry docker build -t "${image}-onbuild" onbuild
 
 after_script:
   - docker images

--- a/2/onbuild/Dockerfile
+++ b/2/onbuild/Dockerfile
@@ -1,9 +1,0 @@
-FROM pypy:2
-
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
-
-ONBUILD COPY requirements.txt /usr/src/app/
-ONBUILD RUN pip install -r requirements.txt
-
-ONBUILD COPY . /usr/src/app

--- a/3/onbuild/Dockerfile
+++ b/3/onbuild/Dockerfile
@@ -1,9 +1,0 @@
-FROM pypy:3
-
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
-
-ONBUILD COPY requirements.txt /usr/src/app/
-ONBUILD RUN pip install -r requirements.txt
-
-ONBUILD COPY . /usr/src/app

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -63,7 +63,7 @@ for version in "${versions[@]}"; do
 	done
 	versionAliases+=( $version ${aliases[$version]:-} )
 
-	for variant in '' slim onbuild; do
+	for variant in '' slim; do
 		dir="$version${variant:+/$variant}"
 		[ -f "$dir/Dockerfile" ] || continue
 
@@ -75,10 +75,7 @@ for version in "${versions[@]}"; do
 			variantAliases=( "${variantAliases[@]//latest-/}" )
 		fi
 
-		case "$variant" in
-			onbuild) variantArches="$(parentArches "$(dirname "$dir")" )" ;;
-			*)       variantArches="$(parentArches "$dir")" ;;
-		esac
+		variantArches="$(parentArches "$dir")"
 
 		echo
 		cat <<-EOE

--- a/update.sh
+++ b/update.sh
@@ -94,6 +94,4 @@ for version in "${versions[@]}"; do
 			-e 's!%%ARCH-CASE%%!'"$(sed_escape_rhs "$linuxArchCase")"'!g' \
 			"Dockerfile${variant:+-$variant}.template" > "$version/$variant/Dockerfile"
 	done
-
-	sed -ri 's/^(FROM pypy):.*/\1:'"$version"'/' "$version/onbuild/Dockerfile"
 done


### PR DESCRIPTION
See https://github.com/docker-library/official-images/issues/2076 and https://github.com/docker-library/docs/pull/911.

I figured the recent 5.10.0 release was as good a time as any to finally pull the plug on these.