### PR TITLE
Delete Python test files like in Python image

### DIFF
--- a/2/Dockerfile
+++ b/2/Dockerfile
@@ -35,6 +35,7 @@ RUN set -ex; \
 	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy2-v${PYPY_VERSION}-${pypyArch}.tar.bz2"; \
 	echo "$sha256 *pypy.tar.bz2" | sha256sum -c; \
 	tar -xjC /usr/local --strip-components=1 -f pypy.tar.bz2; \
+	find /usr/local/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
 	\
 	pypy --version

--- a/2/slim/Dockerfile
+++ b/2/slim/Dockerfile
@@ -43,6 +43,7 @@ RUN set -ex; \
 	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy2-v${PYPY_VERSION}-${pypyArch}.tar.bz2"; \
 	echo "$sha256 *pypy.tar.bz2" | sha256sum -c; \
 	tar -xjC /usr/local --strip-components=1 -f pypy.tar.bz2; \
+	find /usr/local/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
 	\
 	pypy --version; \

--- a/3/Dockerfile
+++ b/3/Dockerfile
@@ -35,6 +35,7 @@ RUN set -ex; \
 	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy3-v${PYPY_VERSION}-${pypyArch}.tar.bz2"; \
 	echo "$sha256 *pypy.tar.bz2" | sha256sum -c; \
 	tar -xjC /usr/local --strip-components=1 -f pypy.tar.bz2; \
+	find /usr/local/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
 	\
 	pypy3 --version

--- a/3/slim/Dockerfile
+++ b/3/slim/Dockerfile
@@ -43,6 +43,7 @@ RUN set -ex; \
 	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy3-v${PYPY_VERSION}-${pypyArch}.tar.bz2"; \
 	echo "$sha256 *pypy.tar.bz2" | sha256sum -c; \
 	tar -xjC /usr/local --strip-components=1 -f pypy.tar.bz2; \
+	find /usr/local/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
 	\
 	pypy3 --version; \

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -34,6 +34,7 @@ RUN set -ex; \
 	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/%%TAR%%-v${PYPY_VERSION}-${pypyArch}.tar.bz2"; \
 	echo "$sha256 *pypy.tar.bz2" | sha256sum -c; \
 	tar -xjC /usr/local --strip-components=1 -f pypy.tar.bz2; \
+	find /usr/local/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
 	\
 	%%CMD%% --version; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -26,6 +26,7 @@ RUN set -ex; \
 	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/%%TAR%%-v${PYPY_VERSION}-${pypyArch}.tar.bz2"; \
 	echo "$sha256 *pypy.tar.bz2" | sha256sum -c; \
 	tar -xjC /usr/local --strip-components=1 -f pypy.tar.bz2; \
+	find /usr/local/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
 	\
 	%%CMD%% --version


### PR DESCRIPTION
There are other files that could be cleaned up here too (e.g. there's at least one bundled pip in `lib-python`), but this is a start. This doesn't delete `.pyc`/`.pyo` files like in the Python image since PyPy doesn't produce those.

This saves ~15MB of uncompressed image size for PyPy 2 for me.