### PR TITLE
Update PyPy 3.x to Debian Stretch

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -30,14 +30,21 @@ RUN set -ex; \
 		*) echo >&2 "error: current architecture ($dpkgArch) does not have a corresponding PyPy $PYPY_VERSION binary release"; exit 1 ;; \
 	esac; \
 	\
-	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v${PYPY_VERSION}-${pypyArch}.tar.bz2"; \
+	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
 	echo "$sha256 *pypy.tar.bz2" | sha256sum -c; \
 	tar -xjC /usr/local --strip-components=1 -f pypy.tar.bz2; \
 	find /usr/local/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
 	\
 # smoke test
-	pypy --version
+	pypy --version; \
+	\
+	if [ -f /usr/local/lib_pypy/_ssl_build.py ]; then \
+# on pypy3, rebuild ffi bits for compatibility with Debian Stretch+ (https://github.com/docker-library/pypy/issues/24#issuecomment-409408657)
+		cd /usr/local/lib_pypy; \
+		pypy _ssl_build.py; \
+# TODO rebuild other cffi modules here too? (other _*_build.py files)
+	fi
 
 RUN set -ex; \
 	\

--- a/2.7/slim/Dockerfile
+++ b/2.7/slim/Dockerfile
@@ -37,6 +37,8 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		bzip2 \
 		wget \
+# sometimes "pypy" itself is linked against libncurses5, sometimes it's a ".so" file in "/usr/local/lib_pypy"
+		libncurses5 \
 	; \
 	\
 	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
@@ -70,6 +72,14 @@ RUN set -ex; \
 	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+	find /usr/local -type f -executable -exec ldd '{}' ';' \
+		| awk '/=>/ { print $(NF-1) }' \
+		| sort -u \
+		| xargs -r dpkg-query --search \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -r apt-mark manual \
+	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 # smoke test again, to be sure
 	rm -rf /var/lib/apt/lists/*; \

--- a/2.7/slim/Dockerfile
+++ b/2.7/slim/Dockerfile
@@ -38,9 +38,8 @@ RUN set -ex; \
 		bzip2 \
 		wget \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
-	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v${PYPY_VERSION}-${pypyArch}.tar.bz2"; \
+	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
 	echo "$sha256 *pypy.tar.bz2" | sha256sum -c; \
 	tar -xjC /usr/local --strip-components=1 -f pypy.tar.bz2; \
 	find /usr/local/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
@@ -48,6 +47,14 @@ RUN set -ex; \
 	\
 # smoke test
 	pypy --version; \
+	\
+	if [ -f /usr/local/lib_pypy/_ssl_build.py ]; then \
+# on pypy3, rebuild ffi bits for compatibility with Debian Stretch+ (https://github.com/docker-library/pypy/issues/24#issuecomment-409408657)
+		apt-get install -y --no-install-recommends gcc libc6-dev libssl-dev; \
+		cd /usr/local/lib_pypy; \
+		pypy _ssl_build.py; \
+# TODO rebuild other cffi modules here too? (other _*_build.py files)
+	fi; \
 	\
 	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
 	\
@@ -65,6 +72,7 @@ RUN set -ex; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 # smoke test again, to be sure
+	rm -rf /var/lib/apt/lists/*; \
 	pypy --version; \
 	pip --version
 

--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:jessie
+FROM buildpack-deps:stretch
 
 # ensure local pypy is preferred over distribution pypy
 ENV PATH /usr/local/bin:$PATH
@@ -30,14 +30,21 @@ RUN set -ex; \
 		*) echo >&2 "error: current architecture ($dpkgArch) does not have a corresponding PyPy $PYPY_VERSION binary release"; exit 1 ;; \
 	esac; \
 	\
-	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy3.5-v${PYPY_VERSION}-${pypyArch}.tar.bz2"; \
+	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy3.5-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
 	echo "$sha256 *pypy.tar.bz2" | sha256sum -c; \
 	tar -xjC /usr/local --strip-components=1 -f pypy.tar.bz2; \
 	find /usr/local/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
 	\
 # smoke test
-	pypy3 --version
+	pypy3 --version; \
+	\
+	if [ -f /usr/local/lib_pypy/_ssl_build.py ]; then \
+# on pypy3, rebuild ffi bits for compatibility with Debian Stretch+ (https://github.com/docker-library/pypy/issues/24#issuecomment-409408657)
+		cd /usr/local/lib_pypy; \
+		pypy3 _ssl_build.py; \
+# TODO rebuild other cffi modules here too? (other _*_build.py files)
+	fi
 
 RUN set -ex; \
 	\

--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -27,6 +27,10 @@ RUN set -ex; \
 		amd64) pypyArch='linux64'; sha256='729e3c54325969c98bd3658c6342b9f5987b96bad1d6def04250a08401b54c4b' ;; \
 # i386
 		i386) pypyArch='linux32'; sha256='b8db8fbca9621de8ea8cd7184b322f2dddb2f385e8e5a63dfb75bb3fea4b2e3f' ;; \
+# ppc64le
+		ppc64el) pypyArch='ppc64le'; sha256='2912884da05abc2cdf71dd337c3f280095351312c1a1732a52b6878174a0fd02' ;; \
+# s390x
+		s390x) pypyArch='s390x'; sha256='d588b045cc0d3a75c31fce54c1d181b1206ad9a5dd272fe79160a6268401605f' ;; \
 		*) echo >&2 "error: current architecture ($dpkgArch) does not have a corresponding PyPy $PYPY_VERSION binary release"; exit 1 ;; \
 	esac; \
 	\

--- a/3.5/slim/Dockerfile
+++ b/3.5/slim/Dockerfile
@@ -41,6 +41,8 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		bzip2 \
 		wget \
+# sometimes "pypy3" itself is linked against libncurses5, sometimes it's a ".so" file in "/usr/local/lib_pypy"
+		libncurses5 \
 	; \
 	\
 	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy3.5-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
@@ -49,8 +51,6 @@ RUN set -ex; \
 	find /usr/local/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
 	\
-# ppc64le and s390x link against libncurses.so.5 (https://bitbucket.org/pypy/pypy/issues/2646)
-	if ldd /usr/local/bin/pypy3 2>&1 | grep -q 'libncurses.so.5 => not found'; then apt-get install -y --no-install-recommends libncurses5; savedAptMark="$savedAptMark libncurses5"; fi; \
 # smoke test
 	pypy3 --version; \
 	\
@@ -76,6 +76,14 @@ RUN set -ex; \
 	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+	find /usr/local -type f -executable -exec ldd '{}' ';' \
+		| awk '/=>/ { print $(NF-1) }' \
+		| sort -u \
+		| xargs -r dpkg-query --search \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -r apt-mark manual \
+	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 # smoke test again, to be sure
 	rm -rf /var/lib/apt/lists/*; \

--- a/3.5/slim/Dockerfile
+++ b/3.5/slim/Dockerfile
@@ -29,6 +29,10 @@ RUN set -ex; \
 		amd64) pypyArch='linux64'; sha256='729e3c54325969c98bd3658c6342b9f5987b96bad1d6def04250a08401b54c4b' ;; \
 # i386
 		i386) pypyArch='linux32'; sha256='b8db8fbca9621de8ea8cd7184b322f2dddb2f385e8e5a63dfb75bb3fea4b2e3f' ;; \
+# ppc64le
+		ppc64el) pypyArch='ppc64le'; sha256='2912884da05abc2cdf71dd337c3f280095351312c1a1732a52b6878174a0fd02' ;; \
+# s390x
+		s390x) pypyArch='s390x'; sha256='d588b045cc0d3a75c31fce54c1d181b1206ad9a5dd272fe79160a6268401605f' ;; \
 		*) echo >&2 "error: current architecture ($dpkgArch) does not have a corresponding PyPy $PYPY_VERSION binary release"; exit 1 ;; \
 	esac; \
 	\
@@ -45,6 +49,8 @@ RUN set -ex; \
 	find /usr/local/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
 	\
+# ppc64le and s390x link against libncurses.so.5 (https://bitbucket.org/pypy/pypy/issues/2646)
+	if ldd /usr/local/bin/pypy3 2>&1 | grep -q 'libncurses.so.5 => not found'; then apt-get install -y --no-install-recommends libncurses5; savedAptMark="$savedAptMark libncurses5"; fi; \
 # smoke test
 	pypy3 --version; \
 	\

--- a/3.5/slim/Dockerfile
+++ b/3.5/slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie-slim
+FROM debian:stretch-slim
 
 # ensure local pypy is preferred over distribution pypy
 ENV PATH /usr/local/bin:$PATH
@@ -38,9 +38,8 @@ RUN set -ex; \
 		bzip2 \
 		wget \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
-	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy3.5-v${PYPY_VERSION}-${pypyArch}.tar.bz2"; \
+	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy3.5-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
 	echo "$sha256 *pypy.tar.bz2" | sha256sum -c; \
 	tar -xjC /usr/local --strip-components=1 -f pypy.tar.bz2; \
 	find /usr/local/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
@@ -48,6 +47,14 @@ RUN set -ex; \
 	\
 # smoke test
 	pypy3 --version; \
+	\
+	if [ -f /usr/local/lib_pypy/_ssl_build.py ]; then \
+# on pypy3, rebuild ffi bits for compatibility with Debian Stretch+ (https://github.com/docker-library/pypy/issues/24#issuecomment-409408657)
+		apt-get install -y --no-install-recommends gcc libc6-dev libssl-dev; \
+		cd /usr/local/lib_pypy; \
+		pypy3 _ssl_build.py; \
+# TODO rebuild other cffi modules here too? (other _*_build.py files)
+	fi; \
 	\
 	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
 	\
@@ -65,6 +72,7 @@ RUN set -ex; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 # smoke test again, to be sure
+	rm -rf /var/lib/apt/lists/*; \
 	pypy3 --version; \
 	pip --version
 

--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -27,6 +27,8 @@ RUN set -ex; \
 		amd64) pypyArch='linux64'; sha256='270dd06633cf03337e6f815d7235e790e90dabba6f4b6345c9745121006925fc' ;; \
 # i386
 		i386) pypyArch='linux32'; sha256='031bfac61210a6e161bace0691b854dc15d01b0e624dc0588c544ee5e1621a83' ;; \
+# s390x
+		s390x) pypyArch='s390x'; sha256='243cd0cc188a94c1f064f402ae72b8ba4303eb3137eac53c53826472b8005098' ;; \
 		*) echo >&2 "error: current architecture ($dpkgArch) does not have a corresponding PyPy $PYPY_VERSION binary release"; exit 1 ;; \
 	esac; \
 	\

--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:jessie
+FROM buildpack-deps:stretch
 
 # ensure local pypy is preferred over distribution pypy
 ENV PATH /usr/local/bin:$PATH
@@ -30,14 +30,21 @@ RUN set -ex; \
 		*) echo >&2 "error: current architecture ($dpkgArch) does not have a corresponding PyPy $PYPY_VERSION binary release"; exit 1 ;; \
 	esac; \
 	\
-	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v${PYPY_VERSION}-${pypyArch}.tar.bz2"; \
+	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
 	echo "$sha256 *pypy.tar.bz2" | sha256sum -c; \
 	tar -xjC /usr/local --strip-components=1 -f pypy.tar.bz2; \
 	find /usr/local/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
 	\
 # smoke test
-	pypy3 --version
+	pypy3 --version; \
+	\
+	if [ -f /usr/local/lib_pypy/_ssl_build.py ]; then \
+# on pypy3, rebuild ffi bits for compatibility with Debian Stretch+ (https://github.com/docker-library/pypy/issues/24#issuecomment-409408657)
+		cd /usr/local/lib_pypy; \
+		pypy3 _ssl_build.py; \
+# TODO rebuild other cffi modules here too? (other _*_build.py files)
+	fi
 
 RUN set -ex; \
 	\

--- a/3.6/slim/Dockerfile
+++ b/3.6/slim/Dockerfile
@@ -29,6 +29,8 @@ RUN set -ex; \
 		amd64) pypyArch='linux64'; sha256='270dd06633cf03337e6f815d7235e790e90dabba6f4b6345c9745121006925fc' ;; \
 # i386
 		i386) pypyArch='linux32'; sha256='031bfac61210a6e161bace0691b854dc15d01b0e624dc0588c544ee5e1621a83' ;; \
+# s390x
+		s390x) pypyArch='s390x'; sha256='243cd0cc188a94c1f064f402ae72b8ba4303eb3137eac53c53826472b8005098' ;; \
 		*) echo >&2 "error: current architecture ($dpkgArch) does not have a corresponding PyPy $PYPY_VERSION binary release"; exit 1 ;; \
 	esac; \
 	\
@@ -45,6 +47,8 @@ RUN set -ex; \
 	find /usr/local/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
 	\
+# ppc64le and s390x link against libncurses.so.5 (https://bitbucket.org/pypy/pypy/issues/2646)
+	if ldd /usr/local/bin/pypy3 2>&1 | grep -q 'libncurses.so.5 => not found'; then apt-get install -y --no-install-recommends libncurses5; savedAptMark="$savedAptMark libncurses5"; fi; \
 # smoke test
 	pypy3 --version; \
 	\

--- a/3.6/slim/Dockerfile
+++ b/3.6/slim/Dockerfile
@@ -39,6 +39,8 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		bzip2 \
 		wget \
+# sometimes "pypy3" itself is linked against libncurses5, sometimes it's a ".so" file in "/usr/local/lib_pypy"
+		libncurses5 \
 	; \
 	\
 	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
@@ -47,8 +49,6 @@ RUN set -ex; \
 	find /usr/local/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
 	\
-# ppc64le and s390x link against libncurses.so.5 (https://bitbucket.org/pypy/pypy/issues/2646)
-	if ldd /usr/local/bin/pypy3 2>&1 | grep -q 'libncurses.so.5 => not found'; then apt-get install -y --no-install-recommends libncurses5; savedAptMark="$savedAptMark libncurses5"; fi; \
 # smoke test
 	pypy3 --version; \
 	\
@@ -74,6 +74,14 @@ RUN set -ex; \
 	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+	find /usr/local -type f -executable -exec ldd '{}' ';' \
+		| awk '/=>/ { print $(NF-1) }' \
+		| sort -u \
+		| xargs -r dpkg-query --search \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -r apt-mark manual \
+	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 # smoke test again, to be sure
 	rm -rf /var/lib/apt/lists/*; \

--- a/3.6/slim/Dockerfile
+++ b/3.6/slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie-slim
+FROM debian:stretch-slim
 
 # ensure local pypy is preferred over distribution pypy
 ENV PATH /usr/local/bin:$PATH
@@ -38,9 +38,8 @@ RUN set -ex; \
 		bzip2 \
 		wget \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
-	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v${PYPY_VERSION}-${pypyArch}.tar.bz2"; \
+	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
 	echo "$sha256 *pypy.tar.bz2" | sha256sum -c; \
 	tar -xjC /usr/local --strip-components=1 -f pypy.tar.bz2; \
 	find /usr/local/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
@@ -48,6 +47,14 @@ RUN set -ex; \
 	\
 # smoke test
 	pypy3 --version; \
+	\
+	if [ -f /usr/local/lib_pypy/_ssl_build.py ]; then \
+# on pypy3, rebuild ffi bits for compatibility with Debian Stretch+ (https://github.com/docker-library/pypy/issues/24#issuecomment-409408657)
+		apt-get install -y --no-install-recommends gcc libc6-dev libssl-dev; \
+		cd /usr/local/lib_pypy; \
+		pypy3 _ssl_build.py; \
+# TODO rebuild other cffi modules here too? (other _*_build.py files)
+	fi; \
 	\
 	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
 	\
@@ -65,6 +72,7 @@ RUN set -ex; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 # smoke test again, to be sure
+	rm -rf /var/lib/apt/lists/*; \
 	pypy3 --version; \
 	pip --version
 

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -38,6 +38,8 @@ RUN set -ex; \
 	find /usr/local/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
 	\
+# ppc64le and s390x link against libncurses.so.5 (https://bitbucket.org/pypy/pypy/issues/2646)
+	if ldd /usr/local/bin/%%CMD%% 2>&1 | grep -q 'libncurses.so.5 => not found'; then apt-get install -y --no-install-recommends libncurses5; savedAptMark="$savedAptMark libncurses5"; fi; \
 # smoke test
 	%%CMD%% --version; \
 	\

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -30,6 +30,8 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		bzip2 \
 		wget \
+# sometimes "%%CMD%%" itself is linked against libncurses5, sometimes it's a ".so" file in "/usr/local/lib_pypy"
+		libncurses5 \
 	; \
 	\
 	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/%%TAR%%-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
@@ -38,8 +40,6 @@ RUN set -ex; \
 	find /usr/local/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
 	\
-# ppc64le and s390x link against libncurses.so.5 (https://bitbucket.org/pypy/pypy/issues/2646)
-	if ldd /usr/local/bin/%%CMD%% 2>&1 | grep -q 'libncurses.so.5 => not found'; then apt-get install -y --no-install-recommends libncurses5; savedAptMark="$savedAptMark libncurses5"; fi; \
 # smoke test
 	%%CMD%% --version; \
 	\
@@ -65,6 +65,14 @@ RUN set -ex; \
 	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+	find /usr/local -type f -executable -exec ldd '{}' ';' \
+		| awk '/=>/ { print $(NF-1) }' \
+		| sort -u \
+		| xargs -r dpkg-query --search \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -r apt-mark manual \
+	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 # smoke test again, to be sure
 	rm -rf /var/lib/apt/lists/*; \

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -1,4 +1,4 @@
-FROM debian:jessie-slim
+FROM debian:%%BASE%%-slim
 
 # ensure local pypy is preferred over distribution pypy
 ENV PATH /usr/local/bin:$PATH
@@ -31,9 +31,8 @@ RUN set -ex; \
 		bzip2 \
 		wget \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
-	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/%%TAR%%-v${PYPY_VERSION}-${pypyArch}.tar.bz2"; \
+	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/%%TAR%%-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
 	echo "$sha256 *pypy.tar.bz2" | sha256sum -c; \
 	tar -xjC /usr/local --strip-components=1 -f pypy.tar.bz2; \
 	find /usr/local/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
@@ -41,6 +40,14 @@ RUN set -ex; \
 	\
 # smoke test
 	%%CMD%% --version; \
+	\
+	if [ -f /usr/local/lib_pypy/_ssl_build.py ]; then \
+# on pypy3, rebuild ffi bits for compatibility with Debian Stretch+ (https://github.com/docker-library/pypy/issues/24#issuecomment-409408657)
+		apt-get install -y --no-install-recommends gcc libc6-dev libssl-dev; \
+		cd /usr/local/lib_pypy; \
+		%%CMD%% _ssl_build.py; \
+# TODO rebuild other cffi modules here too? (other _*_build.py files)
+	fi; \
 	\
 	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
 	\
@@ -58,6 +65,7 @@ RUN set -ex; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 # smoke test again, to be sure
+	rm -rf /var/lib/apt/lists/*; \
 	%%CMD%% --version; \
 	pip --version
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM buildpack-deps:jessie
+FROM buildpack-deps:%%BASE%%
 
 # ensure local pypy is preferred over distribution pypy
 ENV PATH /usr/local/bin:$PATH
@@ -23,14 +23,21 @@ RUN set -ex; \
 # this "case" statement is generated via "update.sh"
 	%%ARCH-CASE%%; \
 	\
-	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/%%TAR%%-v${PYPY_VERSION}-${pypyArch}.tar.bz2"; \
+	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/%%TAR%%-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
 	echo "$sha256 *pypy.tar.bz2" | sha256sum -c; \
 	tar -xjC /usr/local --strip-components=1 -f pypy.tar.bz2; \
 	find /usr/local/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
 	\
 # smoke test
-	%%CMD%% --version
+	%%CMD%% --version; \
+	\
+	if [ -f /usr/local/lib_pypy/_ssl_build.py ]; then \
+# on pypy3, rebuild ffi bits for compatibility with Debian Stretch+ (https://github.com/docker-library/pypy/issues/24#issuecomment-409408657)
+		cd /usr/local/lib_pypy; \
+		%%CMD%% _ssl_build.py; \
+# TODO rebuild other cffi modules here too? (other _*_build.py files)
+	fi
 
 RUN set -ex; \
 	\

--- a/release-architectures
+++ b/release-architectures
@@ -7,8 +7,6 @@ arm32v5 armel   linux-armel
 arm32v7 armhf   linux-armhf-raring
 i386    i386    linux32
 
-# pypy: error while loading shared libraries: libssl.so.10: cannot open shared object file: No such file or directory
-#ppc64le ppc64el ppc64le
-# pypy: error while loading shared libraries: libssl.so.10: cannot open shared object file: No such file or directory
-#s390x   s390x   s390x
-# https://bitbucket.org/pypy/pypy/issues/2646/s390x-and-ppc64le-releases-link-to
+# see https://bitbucket.org/pypy/pypy/issues/2646 for some s390x/ppc64le caveats (mitigated in 3.x via https://github.com/docker-library/pypy/issues/24#issuecomment-476873691)
+ppc64le ppc64el ppc64le
+s390x   s390x   s390x

--- a/update.sh
+++ b/update.sh
@@ -38,8 +38,8 @@ sed_escape_rhs() {
 travisEnv=
 for version in "${versions[@]}"; do
 	case "$version" in
-		3 | 3.*) cmd='pypy3' ;;
-		2 | 2.*) cmd='pypy' ;;
+		3 | 3.*) cmd='pypy3'; base='stretch' ;;
+		2 | 2.*) cmd='pypy'; base='jessie' ;; # https://github.com/docker-library/pypy/issues/24#issuecomment-476873691
 		*) echo >&2 "error: unknown pypy variant $version"; exit 1 ;;
 	esac
 	pypy="pypy$version"
@@ -94,6 +94,7 @@ for version in "${versions[@]}"; do
 			-e 's!%%PIP_VERSION%%!'"$pipVersion"'!g' \
 			-e 's!%%TAR%%!'"$pypy"'!g' \
 			-e 's!%%CMD%%!'"$cmd"'!g' \
+			-e 's!%%BASE%%!'"$base"'!g' \
 			-e 's!%%ARCH-CASE%%!'"$(sed_escape_rhs "$linuxArchCase")"'!g' \
 			"Dockerfile${variant:+-$variant}.template" > "$version/$variant/Dockerfile"
 		travisEnv='\n  - VERSION='"$version VARIANT=$variant$travisEnv"

--- a/update.sh
+++ b/update.sh
@@ -74,7 +74,6 @@ for version in "${versions[@]}"; do
 
 	linuxArchCase='dpkgArch="$(dpkg --print-architecture)"; '$'\\\n'
 	linuxArchCase+=$'\t''case "${dpkgArch##*-}" in '$'\\\n'
-	haveIBM=
 	for dpkgArch in $(dpkgArches); do
 		bashbrewArch="$(dpkgToBashbrewArch "$dpkgArch")"
 		case "$base/$bashbrewArch" in
@@ -82,8 +81,6 @@ for version in "${versions[@]}"; do
 				echo >&2 "warning: skipping $pypy on $bashbrewArch; https://bitbucket.org/pypy/pypy/issues/2646"
 				continue
 				;;
-
-			*/s390x | */ppc64le) haveIBM=1 ;;
 		esac
 		pypyArch="$(dpkgToPyPyArch "$dpkgArch")"
 		sha256="$(scrapeSha256 "$pypy" "$fullVersion" "$pypyArch")" || :
@@ -108,11 +105,6 @@ for version in "${versions[@]}"; do
 			"Dockerfile${variant:+-$variant}.template" > "$version/$variant/Dockerfile"
 		travisEnv='\n  - VERSION='"$version VARIANT=$variant$travisEnv"
 	done
-
-	if [ -z "$haveIBM" ]; then
-		# no need for s390x/ppc64le libncurses hax
-		sed -i '/libncurses/d' "$version/slim/Dockerfile"
-	fi
 done
 
 travis="$(awk -v 'RS=\n\n' '$1 == "env:" { $0 = "env:'"$travisEnv"'" } { printf "%s%s", $0, RS }' .travis.yml)"


### PR DESCRIPTION
The problematic `.so` file in PyPy3 (that links to old `libssl` releases) can be rebuilt pretty trivially at image build time!

(In PyPy2, the old `libssl` release is linked into `/usr/local/bin/pypy` itself, so there's nothing we can do there short of rebuilding PyPy itself.)

Closes https://github.com/docker-library/pypy/issues/24 (as much as we can)