### PR TITLE
Check get-pip download

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -15,9 +15,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ENV PYPY_VERSION 7.1.1
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 19.2.2
-
 RUN set -ex; \
 	\
 # this "case" statement is generated via "update.sh"
@@ -44,11 +41,24 @@ RUN set -ex; \
 		cd /usr/local/lib_pypy; \
 		pypy _ssl_build.py; \
 # TODO rebuild other cffi modules here too? (other _*_build.py files)
-	fi
+	fi; \
+	find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' +
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 19.2.2
+# https://github.com/pypa/get-pip
+ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/0c72a3b4ece313faccb446a96c84770ccedc5ec5/get-pip.py
+ENV PYTHON_GET_PIP_SHA256 201edc6df416da971e64cc94992d2dd24bc328bada7444f0c4f2031ae31e8dad
 
 RUN set -ex; \
 	\
-	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
+	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
 	\
 	pypy get-pip.py \
 		--disable-pip-version-check \
@@ -58,6 +68,12 @@ RUN set -ex; \
 # smoke test
 	pip --version; \
 	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' +; \
 	rm -f get-pip.py
 
 CMD ["pypy"]

--- a/2.7/slim/Dockerfile
+++ b/2.7/slim/Dockerfile
@@ -17,9 +17,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ENV PYPY_VERSION 7.1.1
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 19.2.2
-
 RUN set -ex; \
 	\
 # this "case" statement is generated via "update.sh"
@@ -58,18 +55,6 @@ RUN set -ex; \
 # TODO rebuild other cffi modules here too? (other _*_build.py files)
 	fi; \
 	\
-	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
-	\
-	pypy get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		"pip==$PYTHON_PIP_VERSION" \
-	; \
-# smoke test
-	pip --version; \
-	\
-	rm -f get-pip.py; \
-	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
 	find /usr/local -type f -executable -exec ldd '{}' ';' \
@@ -84,6 +69,44 @@ RUN set -ex; \
 # smoke test again, to be sure
 	rm -rf /var/lib/apt/lists/*; \
 	pypy --version; \
-	pip --version
+	find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' +
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 19.2.2
+# https://github.com/pypa/get-pip
+ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/0c72a3b4ece313faccb446a96c84770ccedc5ec5/get-pip.py
+ENV PYTHON_GET_PIP_SHA256 201edc6df416da971e64cc94992d2dd24bc328bada7444f0c4f2031ae31e8dad
+
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		wget \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
+	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
+	\
+	pypy get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	apt-get purge -y --auto-remove wget; \
+# smoke test
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py
 
 CMD ["pypy"]

--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -15,9 +15,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ENV PYPY_VERSION 7.0.0
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 19.2.2
-
 RUN set -ex; \
 	\
 # this "case" statement is generated via "update.sh"
@@ -48,11 +45,24 @@ RUN set -ex; \
 		cd /usr/local/lib_pypy; \
 		pypy3 _ssl_build.py; \
 # TODO rebuild other cffi modules here too? (other _*_build.py files)
-	fi
+	fi; \
+	find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' +
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 19.2.2
+# https://github.com/pypa/get-pip
+ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/0c72a3b4ece313faccb446a96c84770ccedc5ec5/get-pip.py
+ENV PYTHON_GET_PIP_SHA256 201edc6df416da971e64cc94992d2dd24bc328bada7444f0c4f2031ae31e8dad
 
 RUN set -ex; \
 	\
-	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
+	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
 	\
 	pypy3 get-pip.py \
 		--disable-pip-version-check \
@@ -62,6 +72,12 @@ RUN set -ex; \
 # smoke test
 	pip --version; \
 	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' +; \
 	rm -f get-pip.py
 
 CMD ["pypy3"]

--- a/3.5/slim/Dockerfile
+++ b/3.5/slim/Dockerfile
@@ -17,9 +17,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ENV PYPY_VERSION 7.0.0
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 19.2.2
-
 RUN set -ex; \
 	\
 # this "case" statement is generated via "update.sh"
@@ -62,18 +59,6 @@ RUN set -ex; \
 # TODO rebuild other cffi modules here too? (other _*_build.py files)
 	fi; \
 	\
-	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
-	\
-	pypy3 get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		"pip==$PYTHON_PIP_VERSION" \
-	; \
-# smoke test
-	pip --version; \
-	\
-	rm -f get-pip.py; \
-	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
 	find /usr/local -type f -executable -exec ldd '{}' ';' \
@@ -88,6 +73,44 @@ RUN set -ex; \
 # smoke test again, to be sure
 	rm -rf /var/lib/apt/lists/*; \
 	pypy3 --version; \
-	pip --version
+	find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' +
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 19.2.2
+# https://github.com/pypa/get-pip
+ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/0c72a3b4ece313faccb446a96c84770ccedc5ec5/get-pip.py
+ENV PYTHON_GET_PIP_SHA256 201edc6df416da971e64cc94992d2dd24bc328bada7444f0c4f2031ae31e8dad
+
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		wget \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
+	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
+	\
+	pypy3 get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	apt-get purge -y --auto-remove wget; \
+# smoke test
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py
 
 CMD ["pypy3"]

--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -15,9 +15,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ENV PYPY_VERSION 7.1.1
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 19.2.2
-
 RUN set -ex; \
 	\
 # this "case" statement is generated via "update.sh"
@@ -46,11 +43,24 @@ RUN set -ex; \
 		cd /usr/local/lib_pypy; \
 		pypy3 _ssl_build.py; \
 # TODO rebuild other cffi modules here too? (other _*_build.py files)
-	fi
+	fi; \
+	find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' +
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 19.2.2
+# https://github.com/pypa/get-pip
+ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/0c72a3b4ece313faccb446a96c84770ccedc5ec5/get-pip.py
+ENV PYTHON_GET_PIP_SHA256 201edc6df416da971e64cc94992d2dd24bc328bada7444f0c4f2031ae31e8dad
 
 RUN set -ex; \
 	\
-	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
+	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
 	\
 	pypy3 get-pip.py \
 		--disable-pip-version-check \
@@ -60,6 +70,12 @@ RUN set -ex; \
 # smoke test
 	pip --version; \
 	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' +; \
 	rm -f get-pip.py
 
 CMD ["pypy3"]

--- a/3.6/slim/Dockerfile
+++ b/3.6/slim/Dockerfile
@@ -17,9 +17,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ENV PYPY_VERSION 7.1.1
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 19.2.2
-
 RUN set -ex; \
 	\
 # this "case" statement is generated via "update.sh"
@@ -60,18 +57,6 @@ RUN set -ex; \
 # TODO rebuild other cffi modules here too? (other _*_build.py files)
 	fi; \
 	\
-	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
-	\
-	pypy3 get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		"pip==$PYTHON_PIP_VERSION" \
-	; \
-# smoke test
-	pip --version; \
-	\
-	rm -f get-pip.py; \
-	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
 	find /usr/local -type f -executable -exec ldd '{}' ';' \
@@ -86,6 +71,44 @@ RUN set -ex; \
 # smoke test again, to be sure
 	rm -rf /var/lib/apt/lists/*; \
 	pypy3 --version; \
-	pip --version
+	find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' +
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 19.2.2
+# https://github.com/pypa/get-pip
+ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/0c72a3b4ece313faccb446a96c84770ccedc5ec5/get-pip.py
+ENV PYTHON_GET_PIP_SHA256 201edc6df416da971e64cc94992d2dd24bc328bada7444f0c4f2031ae31e8dad
+
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		wget \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
+	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
+	\
+	pypy3 get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	apt-get purge -y --auto-remove wget; \
+# smoke test
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py
 
 CMD ["pypy3"]

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -17,9 +17,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ENV PYPY_VERSION %%PYPY_VERSION%%
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION %%PIP_VERSION%%
-
 RUN set -ex; \
 	\
 # this "case" statement is generated via "update.sh"
@@ -51,18 +48,6 @@ RUN set -ex; \
 # TODO rebuild other cffi modules here too? (other _*_build.py files)
 	fi; \
 	\
-	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
-	\
-	%%CMD%% get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		"pip==$PYTHON_PIP_VERSION" \
-	; \
-# smoke test
-	pip --version; \
-	\
-	rm -f get-pip.py; \
-	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
 	find /usr/local -type f -executable -exec ldd '{}' ';' \
@@ -77,6 +62,44 @@ RUN set -ex; \
 # smoke test again, to be sure
 	rm -rf /var/lib/apt/lists/*; \
 	%%CMD%% --version; \
-	pip --version
+	find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' +
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION %%PIP_VERSION%%
+# https://github.com/pypa/get-pip
+ENV PYTHON_GET_PIP_URL %%PYTHON_GET_PIP_URL%%
+ENV PYTHON_GET_PIP_SHA256 %%PYTHON_GET_PIP_SHA256%%
+
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		wget \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
+	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
+	\
+	%%CMD%% get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	apt-get purge -y --auto-remove wget; \
+# smoke test
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py
 
 CMD ["%%CMD%%"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -15,9 +15,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ENV PYPY_VERSION %%PYPY_VERSION%%
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION %%PIP_VERSION%%
-
 RUN set -ex; \
 	\
 # this "case" statement is generated via "update.sh"
@@ -37,11 +34,24 @@ RUN set -ex; \
 		cd /usr/local/lib_pypy; \
 		%%CMD%% _ssl_build.py; \
 # TODO rebuild other cffi modules here too? (other _*_build.py files)
-	fi
+	fi; \
+	find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' +
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION %%PIP_VERSION%%
+# https://github.com/pypa/get-pip
+ENV PYTHON_GET_PIP_URL %%PYTHON_GET_PIP_URL%%
+ENV PYTHON_GET_PIP_SHA256 %%PYTHON_GET_PIP_SHA256%%
 
 RUN set -ex; \
 	\
-	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
+	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
 	\
 	%%CMD%% get-pip.py \
 		--disable-pip-version-check \
@@ -51,6 +61,12 @@ RUN set -ex; \
 # smoke test
 	pip --version; \
 	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' +; \
 	rm -f get-pip.py
 
 CMD ["%%CMD%%"]

--- a/update.sh
+++ b/update.sh
@@ -12,6 +12,9 @@ fi
 versions=( "${versions[@]%/}" )
 
 pipVersion="$(curl -fsSL 'https://pypi.org/pypi/pip/json' | jq -r .info.version)"
+getPipCommit="$(curl -fsSL 'https://github.com/pypa/get-pip/commits/master/get-pip.py.atom' | tac|tac | awk -F '[[:space:]]*[<>/]+' '$2 == "id" && $3 ~ /Commit/ { print $4; exit }')"
+getPipUrl="https://github.com/pypa/get-pip/raw/$getPipCommit/get-pip.py"
+getPipSha256="$(curl -fsSL "$getPipUrl" | sha256sum | cut -d' ' -f1)"
 
 sha256s="$(curl -fsSL 'https://pypy.org/download.html')"
 scrapeSha256() {
@@ -113,6 +116,8 @@ for version in "${versions[@]}"; do
 		sed -r \
 			-e 's!%%PYPY_VERSION%%!'"$fullVersion"'!g' \
 			-e 's!%%PIP_VERSION%%!'"$pipVersion"'!g' \
+			-e 's!%%PYTHON_GET_PIP_URL%%!'"$getPipUrl"'!' \
+			-e 's!%%PYTHON_GET_PIP_SHA256%%!'"$getPipSha256"'!' \
 			-e 's!%%TAR%%!'"$pypy"'!g' \
 			-e 's!%%CMD%%!'"$cmd"'!g' \
 			-e 's!%%BASE%%!'"$base"'!g' \


### PR DESCRIPTION
Copied from https://github.com/docker-library/python/pull/408

Sync the deletion of pyc/pyo files from python image too!

Slim was moved around to separate pip install layer from pypy layer to match regular version and provide better layer caching on pip updates.

```console
$ docker run --rm pypy:2 find /usr/local -depth \( \( -type d -a \( -name test -o -name tests \) \) -o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \) | wc
    595     595   32512
$ docker run --rm pypy:3 find /usr/local -depth \( \( -type d -a \( -name test -o -name tests \) \) -o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \) | wc
    700     700   52092
$ docker run --rm pypy:2-slim find /usr/local -depth \( \( -type d -a \( -name test -o -name tests \) \) -o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \) | wc
    595     595   32512
$ docker run --rm pypy:3-slim find /usr/local -depth \( \( -type d -a \( -name test -o -name tests \) \) -o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \) | wc
    700     700   52092
```