### PR TITLE
Fix s390x builds

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -29,6 +29,15 @@ RUN set -ex; \
 		*) echo >&2 "error: current architecture ($dpkgArch) does not have a corresponding PyPy $PYPY_VERSION binary release"; exit 1 ;; \
 	esac; \
 	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# sometimes "pypy" itself is linked against libexpat1 / libncurses5, sometimes they're ".so" files in "/usr/local/lib_pypy"
+		libexpat1 \
+		libncurses5 \
+# (so we'll add them temporarily, then use "ldd" later to determine which to keep based on usage per architecture)
+	; \
+	\
 	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
 	echo "$sha256 *pypy.tar.bz2" | sha256sum -c; \
 	tar -xjC /usr/local --strip-components=1 -f pypy.tar.bz2; \
@@ -44,6 +53,22 @@ RUN set -ex; \
 		pypy _ssl_build.py; \
 # TODO rebuild other cffi modules here too? (other _*_build.py files)
 	fi; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+	find /usr/local -type f -executable -exec ldd '{}' ';' \
+		| awk '/=>/ { print $(NF-1) }' \
+		| sort -u \
+		| xargs -r dpkg-query --search \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -r apt-mark manual \
+	; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
+# smoke test again, to be sure
+	pypy --version; \
+	\
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests \) \) \

--- a/2.7/slim/Dockerfile
+++ b/2.7/slim/Dockerfile
@@ -33,8 +33,10 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		bzip2 \
 		wget \
-# sometimes "pypy" itself is linked against libncurses5, sometimes it's a ".so" file in "/usr/local/lib_pypy"
+# sometimes "pypy" itself is linked against libexpat1 / libncurses5, sometimes they're ".so" files in "/usr/local/lib_pypy"
+		libexpat1 \
 		libncurses5 \
+# (so we'll add them temporarily, then use "ldd" later to determine which to keep based on usage per architecture)
 	; \
 	\
 	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
@@ -65,9 +67,10 @@ RUN set -ex; \
 		| xargs -r apt-mark manual \
 	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-# smoke test again, to be sure
 	rm -rf /var/lib/apt/lists/*; \
+# smoke test again, to be sure
 	pypy --version; \
+	\
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests \) \) \

--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -33,6 +33,15 @@ RUN set -ex; \
 		*) echo >&2 "error: current architecture ($dpkgArch) does not have a corresponding PyPy $PYPY_VERSION binary release"; exit 1 ;; \
 	esac; \
 	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# sometimes "pypy3" itself is linked against libexpat1 / libncurses5, sometimes they're ".so" files in "/usr/local/lib_pypy"
+		libexpat1 \
+		libncurses5 \
+# (so we'll add them temporarily, then use "ldd" later to determine which to keep based on usage per architecture)
+	; \
+	\
 	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
 	echo "$sha256 *pypy.tar.bz2" | sha256sum -c; \
 	tar -xjC /usr/local --strip-components=1 -f pypy.tar.bz2; \
@@ -48,6 +57,22 @@ RUN set -ex; \
 		pypy3 _ssl_build.py; \
 # TODO rebuild other cffi modules here too? (other _*_build.py files)
 	fi; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+	find /usr/local -type f -executable -exec ldd '{}' ';' \
+		| awk '/=>/ { print $(NF-1) }' \
+		| sort -u \
+		| xargs -r dpkg-query --search \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -r apt-mark manual \
+	; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
+# smoke test again, to be sure
+	pypy3 --version; \
+	\
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests \) \) \

--- a/3.6/slim/Dockerfile
+++ b/3.6/slim/Dockerfile
@@ -37,8 +37,10 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		bzip2 \
 		wget \
-# sometimes "pypy3" itself is linked against libncurses5, sometimes it's a ".so" file in "/usr/local/lib_pypy"
+# sometimes "pypy3" itself is linked against libexpat1 / libncurses5, sometimes they're ".so" files in "/usr/local/lib_pypy"
+		libexpat1 \
 		libncurses5 \
+# (so we'll add them temporarily, then use "ldd" later to determine which to keep based on usage per architecture)
 	; \
 	\
 	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
@@ -69,9 +71,10 @@ RUN set -ex; \
 		| xargs -r apt-mark manual \
 	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-# smoke test again, to be sure
 	rm -rf /var/lib/apt/lists/*; \
+# smoke test again, to be sure
 	pypy3 --version; \
+	\
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests \) \) \

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -24,8 +24,10 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		bzip2 \
 		wget \
-# sometimes "%%CMD%%" itself is linked against libncurses5, sometimes it's a ".so" file in "/usr/local/lib_pypy"
+# sometimes "%%CMD%%" itself is linked against libexpat1 / libncurses5, sometimes they're ".so" files in "/usr/local/lib_pypy"
+		libexpat1 \
 		libncurses5 \
+# (so we'll add them temporarily, then use "ldd" later to determine which to keep based on usage per architecture)
 	; \
 	\
 	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/%%TAR%%-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
@@ -56,9 +58,10 @@ RUN set -ex; \
 		| xargs -r apt-mark manual \
 	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-# smoke test again, to be sure
 	rm -rf /var/lib/apt/lists/*; \
+# smoke test again, to be sure
 	%%CMD%% --version; \
+	\
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests \) \) \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -20,6 +20,15 @@ RUN set -ex; \
 # this "case" statement is generated via "update.sh"
 	%%ARCH-CASE%%; \
 	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# sometimes "%%CMD%%" itself is linked against libexpat1 / libncurses5, sometimes they're ".so" files in "/usr/local/lib_pypy"
+		libexpat1 \
+		libncurses5 \
+# (so we'll add them temporarily, then use "ldd" later to determine which to keep based on usage per architecture)
+	; \
+	\
 	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/%%TAR%%-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
 	echo "$sha256 *pypy.tar.bz2" | sha256sum -c; \
 	tar -xjC /usr/local --strip-components=1 -f pypy.tar.bz2; \
@@ -35,6 +44,22 @@ RUN set -ex; \
 		%%CMD%% _ssl_build.py; \
 # TODO rebuild other cffi modules here too? (other _*_build.py files)
 	fi; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+	find /usr/local -type f -executable -exec ldd '{}' ';' \
+		| awk '/=>/ { print $(NF-1) }' \
+		| sort -u \
+		| xargs -r dpkg-query --search \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -r apt-mark manual \
+	; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
+# smoke test again, to be sure
+	%%CMD%% --version; \
+	\
 	find /usr/local -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests \) \) \


### PR DESCRIPTION
The s390x (and ppc64le) packages updated to also need libexpat1 (on top of libncurses5).

I was hoping this would fix ppc64le too, but it's got an additional segfault in pip:

```console
+ pypy3 get-pip.py --disable-pip-version-check --no-cache-dir pip==20.0.2
Collecting pip==20.0.2
  Downloading pip-20.0.2-py2.py3-none-any.whl (1.4 MB)
Collecting setuptools
  Downloading setuptools-46.1.3-py3-none-any.whl (582 kB)
Collecting wheel
  Downloading wheel-0.34.2-py2.py3-none-any.whl (26 kB)
Installing collected packages: pip, setuptools, wheel
Segmentation fault (core dumped)
```