### PR TITLE
Move from "/usr/local" to "/opt/pypy"

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -1,17 +1,20 @@
 FROM buildpack-deps:buster
 
-# ensure local pypy is preferred over distribution pypy
-ENV PATH /usr/local/bin:$PATH
-
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
 # runtime dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		tcl \
 		tk \
-	&& rm -rf /var/lib/apt/lists/*
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+# ensure local pypy is preferred over distribution pypy
+ENV PATH /opt/pypy/bin:$PATH
 
 ENV PYPY_VERSION 7.3.0
 
@@ -32,23 +35,26 @@ RUN set -ex; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-# sometimes "pypy" itself is linked against libexpat1 / libncurses5, sometimes they're ".so" files in "/usr/local/lib_pypy"
+# sometimes "pypy" itself is linked against libexpat1 / libncurses5, sometimes they're ".so" files in "/opt/pypy/lib_pypy"
 		libexpat1 \
 		libncurses5 \
 # (so we'll add them temporarily, then use "ldd" later to determine which to keep based on usage per architecture)
 	; \
 	\
-	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
+	wget -O pypy.tar.bz2 "https://downloads.python.org/pypy/pypy2.7-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
 	echo "$sha256 *pypy.tar.bz2" | sha256sum -c; \
-	tar -xjC /usr/local --strip-components=1 -f pypy.tar.bz2; \
-	find /usr/local/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
+	mkdir /opt/pypy; \
+	tar -xjC /opt/pypy --strip-components=1 -f pypy.tar.bz2; \
+	find /opt/pypy/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
+	\
+	ln -svT '/opt/pypy/bin/pypy' '/usr/local/bin/pypy'; \
 	\
 # smoke test
 	pypy --version; \
 	\
 # on pypy3, rebuild ffi bits for compatibility with Debian Stretch+
-	cd /usr/local/lib_pypy; \
+	cd /opt/pypy/lib_pypy; \
 # https://github.com/docker-library/pypy/issues/24#issuecomment-409408657
 	if [ -f _ssl_build.py ]; then \
 		pypy _ssl_build.py; \
@@ -61,7 +67,7 @@ RUN set -ex; \
 	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
-	find /usr/local -type f -executable -exec ldd '{}' ';' \
+	find /opt/pypy -type f -executable -exec ldd '{}' ';' \
 		| awk '/=>/ { print $(NF-1) }' \
 		| sort -u \
 		| xargs -r dpkg-query --search \
@@ -74,7 +80,7 @@ RUN set -ex; \
 # smoke test again, to be sure
 	pypy --version; \
 	\
-	find /usr/local -depth \
+	find /opt/pypy -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests \) \) \
 			-o \
@@ -100,7 +106,7 @@ RUN set -ex; \
 # smoke test
 	pip --version; \
 	\
-	find /usr/local -depth \
+	find /opt/pypy -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests \) \) \
 			-o \

--- a/2.7/slim/Dockerfile
+++ b/2.7/slim/Dockerfile
@@ -1,8 +1,5 @@
 FROM debian:buster-slim
 
-# ensure local pypy is preferred over distribution pypy
-ENV PATH /usr/local/bin:$PATH
-
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
@@ -11,6 +8,9 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends ca-certificates; \
 	rm -rf /var/lib/apt/lists/*
+
+# ensure local pypy is preferred over distribution pypy
+ENV PATH /opt/pypy/bin:$PATH
 
 ENV PYPY_VERSION 7.3.0
 
@@ -33,23 +33,26 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		bzip2 \
 		wget \
-# sometimes "pypy" itself is linked against libexpat1 / libncurses5, sometimes they're ".so" files in "/usr/local/lib_pypy"
+# sometimes "pypy" itself is linked against libexpat1 / libncurses5, sometimes they're ".so" files in "/opt/pypy/lib_pypy"
 		libexpat1 \
 		libncurses5 \
 # (so we'll add them temporarily, then use "ldd" later to determine which to keep based on usage per architecture)
 	; \
 	\
-	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
+	wget -O pypy.tar.bz2 "https://downloads.python.org/pypy/pypy2.7-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
 	echo "$sha256 *pypy.tar.bz2" | sha256sum -c; \
-	tar -xjC /usr/local --strip-components=1 -f pypy.tar.bz2; \
-	find /usr/local/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
+	mkdir /opt/pypy; \
+	tar -xjC /opt/pypy --strip-components=1 -f pypy.tar.bz2; \
+	find /opt/pypy/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
+	\
+	ln -svT '/opt/pypy/bin/pypy' '/usr/local/bin/pypy'; \
 	\
 # smoke test
 	pypy --version; \
 	\
 # on pypy3, rebuild ffi bits for compatibility with Debian Stretch+
-	cd /usr/local/lib_pypy; \
+	cd /opt/pypy/lib_pypy; \
 # https://github.com/docker-library/pypy/issues/24#issuecomment-409408657
 	if [ -f _ssl_build.py ]; then \
 		apt-get install -y --no-install-recommends gcc libc6-dev libssl-dev; \
@@ -64,7 +67,7 @@ RUN set -ex; \
 	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
-	find /usr/local -type f -executable -exec ldd '{}' ';' \
+	find /opt/pypy -type f -executable -exec ldd '{}' ';' \
 		| awk '/=>/ { print $(NF-1) }' \
 		| sort -u \
 		| xargs -r dpkg-query --search \
@@ -77,7 +80,7 @@ RUN set -ex; \
 # smoke test again, to be sure
 	pypy --version; \
 	\
-	find /usr/local -depth \
+	find /opt/pypy -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests \) \) \
 			-o \
@@ -109,7 +112,7 @@ RUN set -ex; \
 # smoke test
 	pip --version; \
 	\
-	find /usr/local -depth \
+	find /opt/pypy -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests \) \) \
 			-o \

--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -1,17 +1,20 @@
 FROM buildpack-deps:buster
 
-# ensure local pypy is preferred over distribution pypy
-ENV PATH /usr/local/bin:$PATH
-
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
 # runtime dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		tcl \
 		tk \
-	&& rm -rf /var/lib/apt/lists/*
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+# ensure local pypy is preferred over distribution pypy
+ENV PATH /opt/pypy/bin:$PATH
 
 ENV PYPY_VERSION 7.3.0
 
@@ -36,23 +39,26 @@ RUN set -ex; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-# sometimes "pypy3" itself is linked against libexpat1 / libncurses5, sometimes they're ".so" files in "/usr/local/lib_pypy"
+# sometimes "pypy3" itself is linked against libexpat1 / libncurses5, sometimes they're ".so" files in "/opt/pypy/lib_pypy"
 		libexpat1 \
 		libncurses5 \
 # (so we'll add them temporarily, then use "ldd" later to determine which to keep based on usage per architecture)
 	; \
 	\
-	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
+	wget -O pypy.tar.bz2 "https://downloads.python.org/pypy/pypy3.6-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
 	echo "$sha256 *pypy.tar.bz2" | sha256sum -c; \
-	tar -xjC /usr/local --strip-components=1 -f pypy.tar.bz2; \
-	find /usr/local/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
+	mkdir /opt/pypy; \
+	tar -xjC /opt/pypy --strip-components=1 -f pypy.tar.bz2; \
+	find /opt/pypy/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
+	\
+	ln -svT '/opt/pypy/bin/pypy3' '/usr/local/bin/pypy3'; \
 	\
 # smoke test
 	pypy3 --version; \
 	\
 # on pypy3, rebuild ffi bits for compatibility with Debian Stretch+
-	cd /usr/local/lib_pypy; \
+	cd /opt/pypy/lib_pypy; \
 # https://github.com/docker-library/pypy/issues/24#issuecomment-409408657
 	if [ -f _ssl_build.py ]; then \
 		pypy3 _ssl_build.py; \
@@ -65,7 +71,7 @@ RUN set -ex; \
 	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
-	find /usr/local -type f -executable -exec ldd '{}' ';' \
+	find /opt/pypy -type f -executable -exec ldd '{}' ';' \
 		| awk '/=>/ { print $(NF-1) }' \
 		| sort -u \
 		| xargs -r dpkg-query --search \
@@ -78,7 +84,7 @@ RUN set -ex; \
 # smoke test again, to be sure
 	pypy3 --version; \
 	\
-	find /usr/local -depth \
+	find /opt/pypy -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests \) \) \
 			-o \
@@ -104,7 +110,7 @@ RUN set -ex; \
 # smoke test
 	pip --version; \
 	\
-	find /usr/local -depth \
+	find /opt/pypy -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests \) \) \
 			-o \

--- a/3.6/slim/Dockerfile
+++ b/3.6/slim/Dockerfile
@@ -1,8 +1,5 @@
 FROM debian:buster-slim
 
-# ensure local pypy is preferred over distribution pypy
-ENV PATH /usr/local/bin:$PATH
-
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
@@ -11,6 +8,9 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends ca-certificates; \
 	rm -rf /var/lib/apt/lists/*
+
+# ensure local pypy is preferred over distribution pypy
+ENV PATH /opt/pypy/bin:$PATH
 
 ENV PYPY_VERSION 7.3.0
 
@@ -37,23 +37,26 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		bzip2 \
 		wget \
-# sometimes "pypy3" itself is linked against libexpat1 / libncurses5, sometimes they're ".so" files in "/usr/local/lib_pypy"
+# sometimes "pypy3" itself is linked against libexpat1 / libncurses5, sometimes they're ".so" files in "/opt/pypy/lib_pypy"
 		libexpat1 \
 		libncurses5 \
 # (so we'll add them temporarily, then use "ldd" later to determine which to keep based on usage per architecture)
 	; \
 	\
-	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
+	wget -O pypy.tar.bz2 "https://downloads.python.org/pypy/pypy3.6-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
 	echo "$sha256 *pypy.tar.bz2" | sha256sum -c; \
-	tar -xjC /usr/local --strip-components=1 -f pypy.tar.bz2; \
-	find /usr/local/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
+	mkdir /opt/pypy; \
+	tar -xjC /opt/pypy --strip-components=1 -f pypy.tar.bz2; \
+	find /opt/pypy/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
+	\
+	ln -svT '/opt/pypy/bin/pypy3' '/usr/local/bin/pypy3'; \
 	\
 # smoke test
 	pypy3 --version; \
 	\
 # on pypy3, rebuild ffi bits for compatibility with Debian Stretch+
-	cd /usr/local/lib_pypy; \
+	cd /opt/pypy/lib_pypy; \
 # https://github.com/docker-library/pypy/issues/24#issuecomment-409408657
 	if [ -f _ssl_build.py ]; then \
 		apt-get install -y --no-install-recommends gcc libc6-dev libssl-dev; \
@@ -68,7 +71,7 @@ RUN set -ex; \
 	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
-	find /usr/local -type f -executable -exec ldd '{}' ';' \
+	find /opt/pypy -type f -executable -exec ldd '{}' ';' \
 		| awk '/=>/ { print $(NF-1) }' \
 		| sort -u \
 		| xargs -r dpkg-query --search \
@@ -81,7 +84,7 @@ RUN set -ex; \
 # smoke test again, to be sure
 	pypy3 --version; \
 	\
-	find /usr/local -depth \
+	find /opt/pypy -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests \) \) \
 			-o \
@@ -113,7 +116,7 @@ RUN set -ex; \
 # smoke test
 	pip --version; \
 	\
-	find /usr/local -depth \
+	find /opt/pypy -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests \) \) \
 			-o \

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -1,8 +1,5 @@
 FROM debian:%%BASE%%-slim
 
-# ensure local pypy is preferred over distribution pypy
-ENV PATH /usr/local/bin:$PATH
-
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
@@ -11,6 +8,9 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends ca-certificates; \
 	rm -rf /var/lib/apt/lists/*
+
+# ensure local pypy is preferred over distribution pypy
+ENV PATH /opt/pypy/bin:$PATH
 
 ENV PYPY_VERSION %%PYPY_VERSION%%
 
@@ -24,23 +24,26 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		bzip2 \
 		wget \
-# sometimes "%%CMD%%" itself is linked against libexpat1 / libncurses5, sometimes they're ".so" files in "/usr/local/lib_pypy"
+# sometimes "%%CMD%%" itself is linked against libexpat1 / libncurses5, sometimes they're ".so" files in "/opt/pypy/lib_pypy"
 		libexpat1 \
 		libncurses5 \
 # (so we'll add them temporarily, then use "ldd" later to determine which to keep based on usage per architecture)
 	; \
 	\
-	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/%%TAR%%-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
+	wget -O pypy.tar.bz2 "https://downloads.python.org/pypy/%%TAR%%-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
 	echo "$sha256 *pypy.tar.bz2" | sha256sum -c; \
-	tar -xjC /usr/local --strip-components=1 -f pypy.tar.bz2; \
-	find /usr/local/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
+	mkdir /opt/pypy; \
+	tar -xjC /opt/pypy --strip-components=1 -f pypy.tar.bz2; \
+	find /opt/pypy/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
+	\
+	ln -svT '/opt/pypy/bin/%%CMD%%' '/usr/local/bin/%%CMD%%'; \
 	\
 # smoke test
 	%%CMD%% --version; \
 	\
 # on pypy3, rebuild ffi bits for compatibility with Debian Stretch+
-	cd /usr/local/lib_pypy; \
+	cd /opt/pypy/lib_pypy; \
 # https://github.com/docker-library/pypy/issues/24#issuecomment-409408657
 	if [ -f _ssl_build.py ]; then \
 		apt-get install -y --no-install-recommends gcc libc6-dev libssl-dev; \
@@ -55,7 +58,7 @@ RUN set -ex; \
 	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
-	find /usr/local -type f -executable -exec ldd '{}' ';' \
+	find /opt/pypy -type f -executable -exec ldd '{}' ';' \
 		| awk '/=>/ { print $(NF-1) }' \
 		| sort -u \
 		| xargs -r dpkg-query --search \
@@ -68,7 +71,7 @@ RUN set -ex; \
 # smoke test again, to be sure
 	%%CMD%% --version; \
 	\
-	find /usr/local -depth \
+	find /opt/pypy -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests \) \) \
 			-o \
@@ -100,7 +103,7 @@ RUN set -ex; \
 # smoke test
 	pip --version; \
 	\
-	find /usr/local -depth \
+	find /opt/pypy -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests \) \) \
 			-o \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,17 +1,20 @@
 FROM buildpack-deps:%%BASE%%
 
-# ensure local pypy is preferred over distribution pypy
-ENV PATH /usr/local/bin:$PATH
-
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 
 # runtime dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		tcl \
 		tk \
-	&& rm -rf /var/lib/apt/lists/*
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+# ensure local pypy is preferred over distribution pypy
+ENV PATH /opt/pypy/bin:$PATH
 
 ENV PYPY_VERSION %%PYPY_VERSION%%
 
@@ -23,23 +26,26 @@ RUN set -ex; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-# sometimes "%%CMD%%" itself is linked against libexpat1 / libncurses5, sometimes they're ".so" files in "/usr/local/lib_pypy"
+# sometimes "%%CMD%%" itself is linked against libexpat1 / libncurses5, sometimes they're ".so" files in "/opt/pypy/lib_pypy"
 		libexpat1 \
 		libncurses5 \
 # (so we'll add them temporarily, then use "ldd" later to determine which to keep based on usage per architecture)
 	; \
 	\
-	wget -O pypy.tar.bz2 "https://bitbucket.org/pypy/pypy/downloads/%%TAR%%-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
+	wget -O pypy.tar.bz2 "https://downloads.python.org/pypy/%%TAR%%-v${PYPY_VERSION}-${pypyArch}.tar.bz2" --progress=dot:giga; \
 	echo "$sha256 *pypy.tar.bz2" | sha256sum -c; \
-	tar -xjC /usr/local --strip-components=1 -f pypy.tar.bz2; \
-	find /usr/local/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
+	mkdir /opt/pypy; \
+	tar -xjC /opt/pypy --strip-components=1 -f pypy.tar.bz2; \
+	find /opt/pypy/lib-python -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
+	\
+	ln -svT '/opt/pypy/bin/%%CMD%%' '/usr/local/bin/%%CMD%%'; \
 	\
 # smoke test
 	%%CMD%% --version; \
 	\
 # on pypy3, rebuild ffi bits for compatibility with Debian Stretch+
-	cd /usr/local/lib_pypy; \
+	cd /opt/pypy/lib_pypy; \
 # https://github.com/docker-library/pypy/issues/24#issuecomment-409408657
 	if [ -f _ssl_build.py ]; then \
 		%%CMD%% _ssl_build.py; \
@@ -52,7 +58,7 @@ RUN set -ex; \
 	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
-	find /usr/local -type f -executable -exec ldd '{}' ';' \
+	find /opt/pypy -type f -executable -exec ldd '{}' ';' \
 		| awk '/=>/ { print $(NF-1) }' \
 		| sort -u \
 		| xargs -r dpkg-query --search \
@@ -65,7 +71,7 @@ RUN set -ex; \
 # smoke test again, to be sure
 	%%CMD%% --version; \
 	\
-	find /usr/local -depth \
+	find /opt/pypy -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests \) \) \
 			-o \
@@ -91,7 +97,7 @@ RUN set -ex; \
 # smoke test
 	pip --version; \
 	\
-	find /usr/local -depth \
+	find /opt/pypy -depth \
 		\( \
 			\( -type d -a \( -name test -o -name tests \) \) \
 			-o \

--- a/update.sh
+++ b/update.sh
@@ -45,11 +45,11 @@ for version in "${versions[@]}"; do
 	esac
 	pypy="pypy$version"
 
-	# <td class="name"><a class="execute" href="/pypy/pypy/downloads/pypy-2.4.0-linux64.tar.bz2">pypy-2.4.0-linux64.tar.bz2</a></td>
-	# <td class="name"><a class="execute" href="/pypy/pypy/downloads/pypy3-2.4.0-linux64.tar.bz2">pypy3-2.4.0-linux64.tar.bz2</a></td>
+	# <td class="filelink"><a href="pypy3.6-v7.3.1-aarch64.tar.bz2">pypy3.6-v7.3.1-aarch64.tar.bz2</a></td>
+	# <td class="filelink"><a href="pypy2.7-v7.3.1-aarch64.tar.bz2">pypy2.7-v7.3.1-aarch64.tar.bz2</a></td>
 	IFS=$'\n'
 	tryVersions=( $(
-		curl -fsSL 'https://bitbucket.org/pypy/pypy/downloads/' \
+		curl -fsSL 'https://downloads.python.org/pypy/' \
 			| sed -rn 's/^.*'"$pypy"'-v([0-9.]+(-alpha[0-9]*)?)-linux64.tar.bz2.*$/\1/gp' \
 			| sort -rV
 	) )


### PR DESCRIPTION
This follows upstream's recommendations more closely, and should remove the `ldconfig` warnings we see during certain `apt-get`/`dpkg` operations.

Also, this switches to using https://downloads.python.org/pypy/, which is supposed to be the canonical upstream download location.

Refs #35, especially https://github.com/docker-library/pypy/issues/35#issuecomment-644179330