### PR TITLE
Exclude "s390x" for bullseye+ (due to libffi6 vs libffi7)

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -155,6 +155,10 @@ for version; do
 						) \
 						<(xargs -n1 <<<"$variantArches" | sort)
 				)"
+				if [[ "$v" != *buster ]]; then
+					# "pypy3: error while loading shared libraries: libffi.so.6: cannot open shared object file: No such file or directory"
+					variantArches="$(sed -r -e '/s390x/d' <<<"$variantArches")"
+				fi
 				;;
 		esac
 


### PR DESCRIPTION
> `pypy3: error while loading shared libraries: libffi.so.6: cannot open shared object file: No such file or directory`

<details>
<summary>Diff:</summary>

```diff
$ diff -u <(bashbrew cat pypy) <(bashbrew cat <(./generate-stackbrew-library.sh))
--- /dev/fd/63	2021-08-20 11:29:32.119968516 -0700
+++ /dev/fd/62	2021-08-20 11:29:32.119968516 -0700
@@ -3,12 +3,12 @@
 
 Tags: 3.7-7.3.5-bullseye, 3.7-7.3-bullseye, 3.7-7-bullseye, 3.7-bullseye, 3-7.3.5-bullseye, 3-7.3-bullseye, 3-7-bullseye, 3-bullseye, bullseye
 SharedTags: 3.7-7.3.5, 3.7-7.3, 3.7-7, 3.7, 3-7.3.5, 3-7.3, 3-7, 3, latest
-Architectures: amd64, arm64v8, i386, s390x
+Architectures: amd64, arm64v8, i386
 GitCommit: 2c7223f5fc2fba18bc8e5cb14896668a5c330ae1
 Directory: 3.7/bullseye
 
 Tags: 3.7-7.3.5-slim, 3.7-7.3-slim, 3.7-7-slim, 3.7-slim, 3-7.3.5-slim, 3-7.3-slim, 3-7-slim, 3-slim, slim, 3.7-7.3.5-slim-bullseye, 3.7-7.3-slim-bullseye, 3.7-7-slim-bullseye, 3.7-slim-bullseye, 3-7.3.5-slim-bullseye, 3-7.3-slim-bullseye, 3-7-slim-bullseye, 3-slim-bullseye, slim-bullseye
-Architectures: amd64, arm64v8, i386, s390x
+Architectures: amd64, arm64v8, i386
 GitCommit: 2c7223f5fc2fba18bc8e5cb14896668a5c330ae1
 Directory: 3.7/slim-bullseye
```

</details>