### PR TITLE
Scrape PIP and setuptools versions directly from "ensurepip"

### DIFF
--- a/2.7/bullseye/Dockerfile
+++ b/2.7/bullseye/Dockerfile
@@ -86,10 +86,6 @@ RUN set -eux; \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
 		\) -exec rm -rf '{}' +
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 20.3.4
-# https://github.com/docker-library/python/issues/365
-ENV PYTHON_SETUPTOOLS_VERSION 44.1.1
 # https://github.com/pypa/get-pip
 ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py
 ENV PYTHON_GET_PIP_SHA256 95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218
@@ -99,11 +95,14 @@ RUN set -ex; \
 	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
 	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
 	\
+	pipVersion="$(pypy -c 'import ensurepip; print(ensurepip._PIP_VERSION)')"; \
+	setuptoolsVersion="$(pypy -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)')"; \
+	\
 	pypy get-pip.py \
 		--disable-pip-version-check \
 		--no-cache-dir \
-		"pip == $PYTHON_PIP_VERSION" \
-		"setuptools == $PYTHON_SETUPTOOLS_VERSION" \
+		"pip == $pipVersion" \
+		"setuptools == $setuptoolsVersion" \
 	; \
 # smoke test
 	pip --version; \

--- a/2.7/buster/Dockerfile
+++ b/2.7/buster/Dockerfile
@@ -86,10 +86,6 @@ RUN set -eux; \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
 		\) -exec rm -rf '{}' +
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 20.3.4
-# https://github.com/docker-library/python/issues/365
-ENV PYTHON_SETUPTOOLS_VERSION 44.1.1
 # https://github.com/pypa/get-pip
 ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py
 ENV PYTHON_GET_PIP_SHA256 95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218
@@ -99,11 +95,14 @@ RUN set -ex; \
 	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
 	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
 	\
+	pipVersion="$(pypy -c 'import ensurepip; print(ensurepip._PIP_VERSION)')"; \
+	setuptoolsVersion="$(pypy -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)')"; \
+	\
 	pypy get-pip.py \
 		--disable-pip-version-check \
 		--no-cache-dir \
-		"pip == $PYTHON_PIP_VERSION" \
-		"setuptools == $PYTHON_SETUPTOOLS_VERSION" \
+		"pip == $pipVersion" \
+		"setuptools == $setuptoolsVersion" \
 	; \
 # smoke test
 	pip --version; \

--- a/2.7/slim-bullseye/Dockerfile
+++ b/2.7/slim-bullseye/Dockerfile
@@ -84,10 +84,6 @@ RUN set -eux; \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
 		\) -exec rm -rf '{}' +
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 20.3.4
-# https://github.com/docker-library/python/issues/365
-ENV PYTHON_SETUPTOOLS_VERSION 44.1.1
 # https://github.com/pypa/get-pip
 ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py
 ENV PYTHON_GET_PIP_SHA256 95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218
@@ -100,11 +96,14 @@ RUN set -ex; \
 	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
 	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
 	\
+	pipVersion="$(pypy -c 'import ensurepip; print(ensurepip._PIP_VERSION)')"; \
+	setuptoolsVersion="$(pypy -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)')"; \
+	\
 	pypy get-pip.py \
 		--disable-pip-version-check \
 		--no-cache-dir \
-		"pip == $PYTHON_PIP_VERSION" \
-		"setuptools == $PYTHON_SETUPTOOLS_VERSION" \
+		"pip == $pipVersion" \
+		"setuptools == $setuptoolsVersion" \
 	; \
 	apt-get purge -y --auto-remove wget; \
 # smoke test

--- a/2.7/slim-buster/Dockerfile
+++ b/2.7/slim-buster/Dockerfile
@@ -84,10 +84,6 @@ RUN set -eux; \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
 		\) -exec rm -rf '{}' +
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 20.3.4
-# https://github.com/docker-library/python/issues/365
-ENV PYTHON_SETUPTOOLS_VERSION 44.1.1
 # https://github.com/pypa/get-pip
 ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py
 ENV PYTHON_GET_PIP_SHA256 95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218
@@ -100,11 +96,14 @@ RUN set -ex; \
 	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
 	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
 	\
+	pipVersion="$(pypy -c 'import ensurepip; print(ensurepip._PIP_VERSION)')"; \
+	setuptoolsVersion="$(pypy -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)')"; \
+	\
 	pypy get-pip.py \
 		--disable-pip-version-check \
 		--no-cache-dir \
-		"pip == $PYTHON_PIP_VERSION" \
-		"setuptools == $PYTHON_SETUPTOOLS_VERSION" \
+		"pip == $pipVersion" \
+		"setuptools == $setuptoolsVersion" \
 	; \
 	apt-get purge -y --auto-remove wget; \
 # smoke test

--- a/2.7/windows/windowsservercore-1809/Dockerfile
+++ b/2.7/windows/windowsservercore-1809/Dockerfile
@@ -88,10 +88,6 @@ RUN $url = 'https://downloads.python.org/pypy/pypy2.7-v7.3.5-win64.zip'; \
 	\
 	Write-Host 'Complete.'
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 20.3.4
-# https://github.com/docker-library/python/issues/365
-ENV PYTHON_SETUPTOOLS_VERSION 44.1.1
 # https://github.com/pypa/get-pip
 ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py
 ENV PYTHON_GET_PIP_SHA256 95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218
@@ -105,12 +101,15 @@ RUN Write-Host ('Downloading get-pip.py ({0}) ...' -f $env:PYTHON_GET_PIP_URL); 
 		exit 1; \
 	}; \
 	\
-	Write-Host ('Installing "pip == {0}" ...' -f $env:PYTHON_PIP_VERSION); \
+	$pipVersion = & pypy -c 'import ensurepip; print(ensurepip._PIP_VERSION)'; \
+	$setuptoolsVersion = & pypy -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)'; \
+	\
+	Write-Host ('Installing "pip == {0}", "setuptools == {1}" ...' -f $pipVersion, $setuptoolsVersion); \
 	pypy get-pip.py \
 		--disable-pip-version-check \
 		--no-cache-dir \
-		('pip == {0}' -f $env:PYTHON_PIP_VERSION) \
-		('setuptools == {0}' -f $env:PYTHON_SETUPTOOLS_VERSION) \
+		('pip == {0}' -f $pipVersion) \
+		('setuptools == {0}' -f $setuptoolsVersion) \
 	; \
 	Remove-Item get-pip.py -Force; \
 	\

--- a/3.7/bullseye/Dockerfile
+++ b/3.7/bullseye/Dockerfile
@@ -102,10 +102,6 @@ RUN set -eux; \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
 		\) -exec rm -rf '{}' +
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 20.3.4
-# https://github.com/docker-library/python/issues/365
-ENV PYTHON_SETUPTOOLS_VERSION 44.1.1
 # https://github.com/pypa/get-pip
 ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py
 ENV PYTHON_GET_PIP_SHA256 95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218
@@ -115,11 +111,14 @@ RUN set -ex; \
 	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
 	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
 	\
+	pipVersion="$(pypy3 -c 'import ensurepip; print(ensurepip._PIP_VERSION)')"; \
+	setuptoolsVersion="$(pypy3 -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)')"; \
+	\
 	pypy3 get-pip.py \
 		--disable-pip-version-check \
 		--no-cache-dir \
-		"pip == $PYTHON_PIP_VERSION" \
-		"setuptools == $PYTHON_SETUPTOOLS_VERSION" \
+		"pip == $pipVersion" \
+		"setuptools == $setuptoolsVersion" \
 	; \
 # smoke test
 	pip --version; \

--- a/3.7/buster/Dockerfile
+++ b/3.7/buster/Dockerfile
@@ -102,10 +102,6 @@ RUN set -eux; \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
 		\) -exec rm -rf '{}' +
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 20.3.4
-# https://github.com/docker-library/python/issues/365
-ENV PYTHON_SETUPTOOLS_VERSION 44.1.1
 # https://github.com/pypa/get-pip
 ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py
 ENV PYTHON_GET_PIP_SHA256 95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218
@@ -115,11 +111,14 @@ RUN set -ex; \
 	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
 	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
 	\
+	pipVersion="$(pypy3 -c 'import ensurepip; print(ensurepip._PIP_VERSION)')"; \
+	setuptoolsVersion="$(pypy3 -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)')"; \
+	\
 	pypy3 get-pip.py \
 		--disable-pip-version-check \
 		--no-cache-dir \
-		"pip == $PYTHON_PIP_VERSION" \
-		"setuptools == $PYTHON_SETUPTOOLS_VERSION" \
+		"pip == $pipVersion" \
+		"setuptools == $setuptoolsVersion" \
 	; \
 # smoke test
 	pip --version; \

--- a/3.7/slim-bullseye/Dockerfile
+++ b/3.7/slim-bullseye/Dockerfile
@@ -102,10 +102,6 @@ RUN set -eux; \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
 		\) -exec rm -rf '{}' +
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 20.3.4
-# https://github.com/docker-library/python/issues/365
-ENV PYTHON_SETUPTOOLS_VERSION 44.1.1
 # https://github.com/pypa/get-pip
 ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py
 ENV PYTHON_GET_PIP_SHA256 95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218
@@ -118,11 +114,14 @@ RUN set -ex; \
 	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
 	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
 	\
+	pipVersion="$(pypy3 -c 'import ensurepip; print(ensurepip._PIP_VERSION)')"; \
+	setuptoolsVersion="$(pypy3 -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)')"; \
+	\
 	pypy3 get-pip.py \
 		--disable-pip-version-check \
 		--no-cache-dir \
-		"pip == $PYTHON_PIP_VERSION" \
-		"setuptools == $PYTHON_SETUPTOOLS_VERSION" \
+		"pip == $pipVersion" \
+		"setuptools == $setuptoolsVersion" \
 	; \
 	apt-get purge -y --auto-remove wget; \
 # smoke test

--- a/3.7/slim-buster/Dockerfile
+++ b/3.7/slim-buster/Dockerfile
@@ -102,10 +102,6 @@ RUN set -eux; \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
 		\) -exec rm -rf '{}' +
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 20.3.4
-# https://github.com/docker-library/python/issues/365
-ENV PYTHON_SETUPTOOLS_VERSION 44.1.1
 # https://github.com/pypa/get-pip
 ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py
 ENV PYTHON_GET_PIP_SHA256 95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218
@@ -118,11 +114,14 @@ RUN set -ex; \
 	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
 	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
 	\
+	pipVersion="$(pypy3 -c 'import ensurepip; print(ensurepip._PIP_VERSION)')"; \
+	setuptoolsVersion="$(pypy3 -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)')"; \
+	\
 	pypy3 get-pip.py \
 		--disable-pip-version-check \
 		--no-cache-dir \
-		"pip == $PYTHON_PIP_VERSION" \
-		"setuptools == $PYTHON_SETUPTOOLS_VERSION" \
+		"pip == $pipVersion" \
+		"setuptools == $setuptoolsVersion" \
 	; \
 	apt-get purge -y --auto-remove wget; \
 # smoke test

--- a/3.7/windows/windowsservercore-1809/Dockerfile
+++ b/3.7/windows/windowsservercore-1809/Dockerfile
@@ -85,10 +85,6 @@ RUN $url = 'https://downloads.python.org/pypy/pypy3.7-v7.3.5-win64.zip'; \
 	\
 	Write-Host 'Complete.'
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 20.3.4
-# https://github.com/docker-library/python/issues/365
-ENV PYTHON_SETUPTOOLS_VERSION 44.1.1
 # https://github.com/pypa/get-pip
 ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py
 ENV PYTHON_GET_PIP_SHA256 95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218
@@ -102,12 +98,15 @@ RUN Write-Host ('Downloading get-pip.py ({0}) ...' -f $env:PYTHON_GET_PIP_URL); 
 		exit 1; \
 	}; \
 	\
-	Write-Host ('Installing "pip == {0}" ...' -f $env:PYTHON_PIP_VERSION); \
+	$pipVersion = & pypy3 -c 'import ensurepip; print(ensurepip._PIP_VERSION)'; \
+	$setuptoolsVersion = & pypy3 -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)'; \
+	\
+	Write-Host ('Installing "pip == {0}", "setuptools == {1}" ...' -f $pipVersion, $setuptoolsVersion); \
 	pypy3 get-pip.py \
 		--disable-pip-version-check \
 		--no-cache-dir \
-		('pip == {0}' -f $env:PYTHON_PIP_VERSION) \
-		('setuptools == {0}' -f $env:PYTHON_SETUPTOOLS_VERSION) \
+		('pip == {0}' -f $pipVersion) \
+		('setuptools == {0}' -f $setuptoolsVersion) \
 	; \
 	Remove-Item get-pip.py -Force; \
 	\

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -130,10 +130,6 @@ RUN set -eux; \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
 		\) -exec rm -rf '{}' +
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION {{ .pip.version }}
-# https://github.com/docker-library/python/issues/365
-ENV PYTHON_SETUPTOOLS_VERSION {{ .setuptools.version }}
 # https://github.com/pypa/get-pip
 ENV PYTHON_GET_PIP_URL {{ ."get-pip".url }}
 ENV PYTHON_GET_PIP_SHA256 {{ ."get-pip".sha256 }}
@@ -148,11 +144,14 @@ RUN set -ex; \
 	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
 	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
 	\
+	pipVersion="$({{ cmd }} -c 'import ensurepip; print(ensurepip._PIP_VERSION)')"; \
+	setuptoolsVersion="$({{ cmd }} -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)')"; \
+	\
 	{{ cmd }} get-pip.py \
 		--disable-pip-version-check \
 		--no-cache-dir \
-		"pip == $PYTHON_PIP_VERSION" \
-		"setuptools == $PYTHON_SETUPTOOLS_VERSION" \
+		"pip == $pipVersion" \
+		"setuptools == $setuptoolsVersion" \
 	; \
 {{ if is_slim then ( -}}
 	apt-get purge -y --auto-remove wget; \

--- a/Dockerfile-windows-servercore.template
+++ b/Dockerfile-windows-servercore.template
@@ -86,10 +86,6 @@ RUN $url = '{{ .arches["windows-amd64"].url }}'; \
 	\
 	Write-Host 'Complete.'
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION {{ .pip.version }}
-# https://github.com/docker-library/python/issues/365
-ENV PYTHON_SETUPTOOLS_VERSION {{ .setuptools.version }}
 # https://github.com/pypa/get-pip
 ENV PYTHON_GET_PIP_URL {{ ."get-pip".url }}
 ENV PYTHON_GET_PIP_SHA256 {{ ."get-pip".sha256 }}
@@ -103,12 +99,15 @@ RUN Write-Host ('Downloading get-pip.py ({0}) ...' -f $env:PYTHON_GET_PIP_URL); 
 		exit 1; \
 	}; \
 	\
-	Write-Host ('Installing "pip == {0}" ...' -f $env:PYTHON_PIP_VERSION); \
+	$pipVersion = & {{ cmd }} -c 'import ensurepip; print(ensurepip._PIP_VERSION)'; \
+	$setuptoolsVersion = & {{ cmd }} -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)'; \
+	\
+	Write-Host ('Installing "pip == {0}", "setuptools == {1}" ...' -f $pipVersion, $setuptoolsVersion); \
 	{{ cmd }} get-pip.py \
 		--disable-pip-version-check \
 		--no-cache-dir \
-		('pip == {0}' -f $env:PYTHON_PIP_VERSION) \
-		('setuptools == {0}' -f $env:PYTHON_SETUPTOOLS_VERSION) \
+		('pip == {0}' -f $pipVersion) \
+		('setuptools == {0}' -f $setuptoolsVersion) \
 	; \
 	Remove-Item get-pip.py -Force; \
 	\

--- a/versions.json
+++ b/versions.json
@@ -23,12 +23,6 @@
       "url": "https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py",
       "version": "3843bff3a0a61da5b63ea0b7d34794c5c51a2f11"
     },
-    "pip": {
-      "version": "20.3.4"
-    },
-    "setuptools": {
-      "version": "44.1.1"
-    },
     "variants": [
       "bullseye",
       "slim-bullseye",
@@ -65,12 +59,6 @@
       "sha256": "95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218",
       "url": "https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py",
       "version": "3843bff3a0a61da5b63ea0b7d34794c5c51a2f11"
-    },
-    "pip": {
-      "version": "20.3.4"
-    },
-    "setuptools": {
-      "version": "44.1.1"
     },
     "variants": [
       "bullseye",

--- a/versions.sh
+++ b/versions.sh
@@ -26,30 +26,6 @@ else
 fi
 versions=( "${versions[@]%/}" )
 
-pipVersion="$(
-	curl -fsSL 'https://pypi.org/pypi/pip/json' | jq -r '
-		.releases
-		| keys_unsorted
-		# version 20.x is the last to support Python 2
-		| map(select(startswith("20.") and (test("[^0-9.]") | not)))
-		| max_by(split(".") | map(tonumber))
-	'
-)"
-# https://github.com/docker-library/python/issues/365
-setuptoolsVersion="$(
-	curl -fsSL 'https://pypi.org/pypi/setuptools/json' | jq -r '
-		.releases
-		| keys_unsorted
-		# version 44.x is the last to support Python 2
-		| map(select(startswith("44.")))
-		| max_by(split(".") | map(tonumber))
-	'
-)"
-getPipCommit="$(curl -fsSL "https://github.com/pypa/get-pip/commits/$pipVersion/get-pip.py.atom" | tac|tac | awk -F '[[:space:]]*[<>/]+' '$2 == "id" && $3 ~ /Commit/ { print $4; exit }')"
-getPipUrl="https://github.com/pypa/get-pip/raw/$getPipCommit/get-pip.py"
-getPipSha256="$(curl -fsSL "$getPipUrl" | sha256sum | cut -d' ' -f1)"
-export pipVersion setuptoolsVersion getPipCommit getPipUrl getPipSha256
-
 sha256s="$(curl -fsSL --compressed 'https://www.pypy.org/checksums.html')"
 pypy_tarball() {
 	local pypy="$1"; shift
@@ -113,12 +89,12 @@ for version in "${versions[@]}"; do
 					url: ("https://downloads.python.org/pypy/" + env.tarball),
 				},
 			},
-			pip: { version: env.pipVersion },
-			setuptools: { version: env.setuptoolsVersion },
 			"get-pip": {
-				version: env.getPipCommit,
-				sha256: env.getPipSha256,
-				url: env.getPipUrl,
+				# https://github.com/pypa/get-pip/releases/tag/20.3.4 (the last release to support Python 2)
+				version: "3843bff3a0a61da5b63ea0b7d34794c5c51a2f11",
+				url: "https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py",
+				sha256: "95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218",
+				# TODO use a newer commit for Python 3
 			},
 		}
 	')"


### PR DESCRIPTION
This is essentially https://github.com/docker-library/python/pull/647, but pulling directly from the `ensurepip` module instead of scraping it in `versions.sh`.

The only bit I'm not sure about is whether we need a newer `get-pip.py` commit that matches the version of PIP being used.

This is a replacement for #61, and closes #62.