### PR TITLE
Move the tags for '3' and 'latest'

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -2,7 +2,7 @@
 set -Eeuo pipefail
 
 declare -A aliases=(
-	['3.7']='3'
+	['3.8']='3'
 	['2.7']='2'
 )
 


### PR DESCRIPTION
PyPy now seems to consider 3.8 a stable release (looking at the table of contents): https://doc.pypy.org/en/latest/release-v7.3.7.html

This would mean that the tag for '3' and therefore 'latest' can be moved to '3.8'.

Related to #65 