### PR TITLE
Remove arm64v8

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -157,8 +157,10 @@ for version; do
 				)"
 				if [[ "$v" != *buster ]]; then
 					# "pypy3: error while loading shared libraries: libffi.so.6: cannot open shared object file: No such file or directory"
-					variantArches="$(sed -r -e '/s390x/d' <<<"$variantArches")"
+					variantArches="$(sed -r -e '/^s390x$/d' <<<"$variantArches")"
 				fi
+				# arm64 has the libffi.so.6 issue plus "pypy: error while loading shared libraries: libtinfow.so.6: cannot open shared object file: No such file or directory" (so everything fails)
+				variantArches="$(sed -r -e '/^arm64v8$/d' <<<"$variantArches")"
 				;;
 		esac
 


### PR DESCRIPTION
On many builds, we get:

> `pypy3: error while loading shared libraries: libffi.so.6: cannot open shared object file: No such file or directory`

Which we can't resolve on Bullseye+ (same as s390x).

On others, we get:

> `pypy: error while loading shared libraries: libtinfow.so.6: cannot open shared object file: No such file or directory`

Which appears to be a CentOS-specific library name and I couldn't convince `pypy` to be satisfied by any symlinks to either `libtinfo` or `libtic` (which were the suggestions I found on other projects for fixing similar linking issues).

See also https://github.com/docker-library/pypy/pull/58 (for where we removed `s390x` bullseye builds).

<details>
<summary>Diff:</summary>

```diff
$ diff -u <(bashbrew cat pypy) <(bashbrew cat <(./generate-stackbrew-library.sh))
--- /dev/fd/63	2022-03-01 11:02:51.922171057 -0800
+++ /dev/fd/62	2022-03-01 11:02:51.922171057 -0800
@@ -3,22 +3,22 @@
 
 Tags: 3.9-7.3.8-bullseye, 3.9-7.3-bullseye, 3.9-7-bullseye, 3.9-bullseye
 SharedTags: 3.9-7.3.8, 3.9-7.3, 3.9-7, 3.9
-Architectures: amd64, arm64v8, i386
+Architectures: amd64, i386
 GitCommit: fdb8ed8f0e8a7efbc8997841914264f126683f0e
 Directory: 3.9/bullseye
 
 Tags: 3.9-7.3.8-slim, 3.9-7.3-slim, 3.9-7-slim, 3.9-slim, 3.9-7.3.8-slim-bullseye, 3.9-7.3-slim-bullseye, 3.9-7-slim-bullseye, 3.9-slim-bullseye
-Architectures: amd64, arm64v8, i386
+Architectures: amd64, i386
 GitCommit: fdb8ed8f0e8a7efbc8997841914264f126683f0e
 Directory: 3.9/slim-bullseye
 
 Tags: 3.9-7.3.8-buster, 3.9-7.3-buster, 3.9-7-buster, 3.9-buster
-Architectures: amd64, arm64v8, i386, s390x
+Architectures: amd64, i386, s390x
 GitCommit: fdb8ed8f0e8a7efbc8997841914264f126683f0e
 Directory: 3.9/buster
 
 Tags: 3.9-7.3.8-slim-buster, 3.9-7.3-slim-buster, 3.9-7-slim-buster, 3.9-slim-buster
-Architectures: amd64, arm64v8, i386, s390x
+Architectures: amd64, i386, s390x
 GitCommit: fdb8ed8f0e8a7efbc8997841914264f126683f0e
 Directory: 3.9/slim-buster
 
@@ -31,22 +31,22 @@
 
 Tags: 3.8-7.3.8-bullseye, 3.8-7.3-bullseye, 3.8-7-bullseye, 3.8-bullseye, 3-7.3.8-bullseye, 3-7.3-bullseye, 3-7-bullseye, 3-bullseye, bullseye
 SharedTags: 3.8-7.3.8, 3.8-7.3, 3.8-7, 3.8, 3-7.3.8, 3-7.3, 3-7, 3, latest
-Architectures: amd64, arm64v8, i386
+Architectures: amd64, i386
 GitCommit: d26c7d6cf69b72d94ead67cae9fed40fd989129a
 Directory: 3.8/bullseye
 
 Tags: 3.8-7.3.8-slim, 3.8-7.3-slim, 3.8-7-slim, 3.8-slim, 3-7.3.8-slim, 3-7.3-slim, 3-7-slim, 3-slim, slim, 3.8-7.3.8-slim-bullseye, 3.8-7.3-slim-bullseye, 3.8-7-slim-bullseye, 3.8-slim-bullseye, 3-7.3.8-slim-bullseye, 3-7.3-slim-bullseye, 3-7-slim-bullseye, 3-slim-bullseye, slim-bullseye
-Architectures: amd64, arm64v8, i386
+Architectures: amd64, i386
 GitCommit: d26c7d6cf69b72d94ead67cae9fed40fd989129a
 Directory: 3.8/slim-bullseye
 
 Tags: 3.8-7.3.8-buster, 3.8-7.3-buster, 3.8-7-buster, 3.8-buster, 3-7.3.8-buster, 3-7.3-buster, 3-7-buster, 3-buster, buster
-Architectures: amd64, arm64v8, i386, s390x
+Architectures: amd64, i386, s390x
 GitCommit: d26c7d6cf69b72d94ead67cae9fed40fd989129a
 Directory: 3.8/buster
 
 Tags: 3.8-7.3.8-slim-buster, 3.8-7.3-slim-buster, 3.8-7-slim-buster, 3.8-slim-buster, 3-7.3.8-slim-buster, 3-7.3-slim-buster, 3-7-slim-buster, 3-slim-buster, slim-buster
-Architectures: amd64, arm64v8, i386, s390x
+Architectures: amd64, i386, s390x
 GitCommit: d26c7d6cf69b72d94ead67cae9fed40fd989129a
 Directory: 3.8/slim-buster
 
@@ -59,22 +59,22 @@
 
 Tags: 3.7-7.3.8-bullseye, 3.7-7.3-bullseye, 3.7-7-bullseye, 3.7-bullseye
 SharedTags: 3.7-7.3.8, 3.7-7.3, 3.7-7, 3.7
-Architectures: amd64, arm64v8, i386
+Architectures: amd64, i386
 GitCommit: 1520fc1d0d4d141c70504e6c6b8065b346aea1df
 Directory: 3.7/bullseye
 
 Tags: 3.7-7.3.8-slim, 3.7-7.3-slim, 3.7-7-slim, 3.7-slim, 3.7-7.3.8-slim-bullseye, 3.7-7.3-slim-bullseye, 3.7-7-slim-bullseye, 3.7-slim-bullseye
-Architectures: amd64, arm64v8, i386
+Architectures: amd64, i386
 GitCommit: 1520fc1d0d4d141c70504e6c6b8065b346aea1df
 Directory: 3.7/slim-bullseye
 
 Tags: 3.7-7.3.8-buster, 3.7-7.3-buster, 3.7-7-buster, 3.7-buster
-Architectures: amd64, arm64v8, i386, s390x
+Architectures: amd64, i386, s390x
 GitCommit: 1520fc1d0d4d141c70504e6c6b8065b346aea1df
 Directory: 3.7/buster
 
 Tags: 3.7-7.3.8-slim-buster, 3.7-7.3-slim-buster, 3.7-7-slim-buster, 3.7-slim-buster
-Architectures: amd64, arm64v8, i386, s390x
+Architectures: amd64, i386, s390x
 GitCommit: 1520fc1d0d4d141c70504e6c6b8065b346aea1df
 Directory: 3.7/slim-buster
 
@@ -87,22 +87,22 @@
 
 Tags: 2.7-7.3.8-bullseye, 2.7-7.3-bullseye, 2.7-7-bullseye, 2.7-bullseye, 2-7.3.8-bullseye, 2-7.3-bullseye, 2-7-bullseye, 2-bullseye
 SharedTags: 2.7-7.3.8, 2.7-7.3, 2.7-7, 2.7, 2-7.3.8, 2-7.3, 2-7, 2
-Architectures: amd64, arm64v8, i386
+Architectures: amd64, i386
 GitCommit: 4d46082ae0ff2771a80e4089ae9e58916134f2b1
 Directory: 2.7/bullseye
 
 Tags: 2.7-7.3.8-slim, 2.7-7.3-slim, 2.7-7-slim, 2.7-slim, 2-7.3.8-slim, 2-7.3-slim, 2-7-slim, 2-slim, 2.7-7.3.8-slim-bullseye, 2.7-7.3-slim-bullseye, 2.7-7-slim-bullseye, 2.7-slim-bullseye, 2-7.3.8-slim-bullseye, 2-7.3-slim-bullseye, 2-7-slim-bullseye, 2-slim-bullseye
-Architectures: amd64, arm64v8, i386
+Architectures: amd64, i386
 GitCommit: 4d46082ae0ff2771a80e4089ae9e58916134f2b1
 Directory: 2.7/slim-bullseye
 
 Tags: 2.7-7.3.8-buster, 2.7-7.3-buster, 2.7-7-buster, 2.7-buster, 2-7.3.8-buster, 2-7.3-buster, 2-7-buster, 2-buster
-Architectures: amd64, arm64v8, i386
+Architectures: amd64, i386
 GitCommit: 4d46082ae0ff2771a80e4089ae9e58916134f2b1
 Directory: 2.7/buster
 
 Tags: 2.7-7.3.8-slim-buster, 2.7-7.3-slim-buster, 2.7-7-slim-buster, 2.7-slim-buster, 2-7.3.8-slim-buster, 2-7.3-slim-buster, 2-7-slim-buster, 2-slim-buster
-Architectures: amd64, arm64v8, i386
+Architectures: amd64, i386
 GitCommit: 4d46082ae0ff2771a80e4089ae9e58916134f2b1
 Directory: 2.7/slim-buster
```

</details>