### PR TITLE
Switch to using the upstream-provided "versions.json" file

### DIFF
--- a/2.7/bullseye/Dockerfile
+++ b/2.7/bullseye/Dockerfile
@@ -22,6 +22,7 @@ ENV LANG C.UTF-8
 # ensure local pypy is preferred over distribution pypy
 ENV PATH /opt/pypy/bin:$PATH
 
+# Python 2.7.18
 ENV PYPY_VERSION 7.3.8
 
 RUN set -eux; \
@@ -33,12 +34,16 @@ RUN set -eux; \
 			sha256='1f2e84fb539ffce233c34769d2f11647955f894be091e85419e05f48011e8940'; \
 			;; \
 		'arm64') \
-			url='https://downloads.python.org/pypy/pypy2.7-v7.3.8-aarch64.tar.bz2'; \
-			sha256='ca1f8d3146c83002ee97615906b0930e821297dcce3063b5b28933a0690ef298'; \
+			url='https://downloads.python.org/pypy/pypy2.7-v7.3.8-aarch64-portable.tar.bz2'; \
+			sha256='b5edfc995d83feea8b4c8aeffccb89753b4b182f076126550bd07cc35faa6208'; \
 			;; \
 		'i386') \
 			url='https://downloads.python.org/pypy/pypy2.7-v7.3.8-linux32.tar.bz2'; \
 			sha256='7c84f173bbcd73d0eb10909259d11b5cc253d4c6ea4492e6da8f2532df9b3da5'; \
+			;; \
+		's390x') \
+			url='https://downloads.python.org/pypy/pypy2.7-v7.3.8-s390x.tar.bz2'; \
+			sha256='b4ae4e708ba84602d976ad6ae391ef2eef4b1896d831b8f2b2ec69927dd92014'; \
 			;; \
 		*) echo >&2 "error: current architecture ($dpkgArch) does not have a corresponding PyPy $PYPY_VERSION binary release"; exit 1 ;; \
 	esac; \

--- a/2.7/buster/Dockerfile
+++ b/2.7/buster/Dockerfile
@@ -22,6 +22,7 @@ ENV LANG C.UTF-8
 # ensure local pypy is preferred over distribution pypy
 ENV PATH /opt/pypy/bin:$PATH
 
+# Python 2.7.18
 ENV PYPY_VERSION 7.3.8
 
 RUN set -eux; \
@@ -33,12 +34,16 @@ RUN set -eux; \
 			sha256='1f2e84fb539ffce233c34769d2f11647955f894be091e85419e05f48011e8940'; \
 			;; \
 		'arm64') \
-			url='https://downloads.python.org/pypy/pypy2.7-v7.3.8-aarch64.tar.bz2'; \
-			sha256='ca1f8d3146c83002ee97615906b0930e821297dcce3063b5b28933a0690ef298'; \
+			url='https://downloads.python.org/pypy/pypy2.7-v7.3.8-aarch64-portable.tar.bz2'; \
+			sha256='b5edfc995d83feea8b4c8aeffccb89753b4b182f076126550bd07cc35faa6208'; \
 			;; \
 		'i386') \
 			url='https://downloads.python.org/pypy/pypy2.7-v7.3.8-linux32.tar.bz2'; \
 			sha256='7c84f173bbcd73d0eb10909259d11b5cc253d4c6ea4492e6da8f2532df9b3da5'; \
+			;; \
+		's390x') \
+			url='https://downloads.python.org/pypy/pypy2.7-v7.3.8-s390x.tar.bz2'; \
+			sha256='b4ae4e708ba84602d976ad6ae391ef2eef4b1896d831b8f2b2ec69927dd92014'; \
 			;; \
 		*) echo >&2 "error: current architecture ($dpkgArch) does not have a corresponding PyPy $PYPY_VERSION binary release"; exit 1 ;; \
 	esac; \

--- a/2.7/slim-bullseye/Dockerfile
+++ b/2.7/slim-bullseye/Dockerfile
@@ -18,6 +18,7 @@ ENV LANG C.UTF-8
 # ensure local pypy is preferred over distribution pypy
 ENV PATH /opt/pypy/bin:$PATH
 
+# Python 2.7.18
 ENV PYPY_VERSION 7.3.8
 
 RUN set -eux; \
@@ -29,12 +30,16 @@ RUN set -eux; \
 			sha256='1f2e84fb539ffce233c34769d2f11647955f894be091e85419e05f48011e8940'; \
 			;; \
 		'arm64') \
-			url='https://downloads.python.org/pypy/pypy2.7-v7.3.8-aarch64.tar.bz2'; \
-			sha256='ca1f8d3146c83002ee97615906b0930e821297dcce3063b5b28933a0690ef298'; \
+			url='https://downloads.python.org/pypy/pypy2.7-v7.3.8-aarch64-portable.tar.bz2'; \
+			sha256='b5edfc995d83feea8b4c8aeffccb89753b4b182f076126550bd07cc35faa6208'; \
 			;; \
 		'i386') \
 			url='https://downloads.python.org/pypy/pypy2.7-v7.3.8-linux32.tar.bz2'; \
 			sha256='7c84f173bbcd73d0eb10909259d11b5cc253d4c6ea4492e6da8f2532df9b3da5'; \
+			;; \
+		's390x') \
+			url='https://downloads.python.org/pypy/pypy2.7-v7.3.8-s390x.tar.bz2'; \
+			sha256='b4ae4e708ba84602d976ad6ae391ef2eef4b1896d831b8f2b2ec69927dd92014'; \
 			;; \
 		*) echo >&2 "error: current architecture ($dpkgArch) does not have a corresponding PyPy $PYPY_VERSION binary release"; exit 1 ;; \
 	esac; \

--- a/2.7/slim-buster/Dockerfile
+++ b/2.7/slim-buster/Dockerfile
@@ -18,6 +18,7 @@ ENV LANG C.UTF-8
 # ensure local pypy is preferred over distribution pypy
 ENV PATH /opt/pypy/bin:$PATH
 
+# Python 2.7.18
 ENV PYPY_VERSION 7.3.8
 
 RUN set -eux; \
@@ -29,12 +30,16 @@ RUN set -eux; \
 			sha256='1f2e84fb539ffce233c34769d2f11647955f894be091e85419e05f48011e8940'; \
 			;; \
 		'arm64') \
-			url='https://downloads.python.org/pypy/pypy2.7-v7.3.8-aarch64.tar.bz2'; \
-			sha256='ca1f8d3146c83002ee97615906b0930e821297dcce3063b5b28933a0690ef298'; \
+			url='https://downloads.python.org/pypy/pypy2.7-v7.3.8-aarch64-portable.tar.bz2'; \
+			sha256='b5edfc995d83feea8b4c8aeffccb89753b4b182f076126550bd07cc35faa6208'; \
 			;; \
 		'i386') \
 			url='https://downloads.python.org/pypy/pypy2.7-v7.3.8-linux32.tar.bz2'; \
 			sha256='7c84f173bbcd73d0eb10909259d11b5cc253d4c6ea4492e6da8f2532df9b3da5'; \
+			;; \
+		's390x') \
+			url='https://downloads.python.org/pypy/pypy2.7-v7.3.8-s390x.tar.bz2'; \
+			sha256='b4ae4e708ba84602d976ad6ae391ef2eef4b1896d831b8f2b2ec69927dd92014'; \
 			;; \
 		*) echo >&2 "error: current architecture ($dpkgArch) does not have a corresponding PyPy $PYPY_VERSION binary release"; exit 1 ;; \
 	esac; \

--- a/2.7/windows/windowsservercore-1809/Dockerfile
+++ b/2.7/windows/windowsservercore-1809/Dockerfile
@@ -47,6 +47,7 @@ RUN $url = 'https://download.microsoft.com/download/6/A/A/6AA4EDFF-645B-48C5-81C
 	\
 	Write-Host 'Complete.'
 
+# Python 2.7.18
 ENV PYPY_VERSION 7.3.8
 
 RUN $url = 'https://downloads.python.org/pypy/pypy2.7-v7.3.8-win64.zip'; \

--- a/3.7/bullseye/Dockerfile
+++ b/3.7/bullseye/Dockerfile
@@ -22,6 +22,7 @@ ENV LANG C.UTF-8
 # ensure local pypy3 is preferred over distribution pypy3
 ENV PATH /opt/pypy/bin:$PATH
 
+# Python 3.7.12
 ENV PYPY_VERSION 7.3.8
 
 RUN set -eux; \
@@ -33,8 +34,8 @@ RUN set -eux; \
 			sha256='409085db79a6d90bfcf4f576dca1538498e65937acfbe03bd4909bdc262ff378'; \
 			;; \
 		'arm64') \
-			url='https://downloads.python.org/pypy/pypy3.7-v7.3.8-aarch64.tar.bz2'; \
-			sha256='4fb2f8281f3aaca72e6fe62ecc5fc054fcc79cd061ca3e0eea730f7d82d610d4'; \
+			url='https://downloads.python.org/pypy/pypy3.7-v7.3.8-aarch64-portable.tar.bz2'; \
+			sha256='639c76f128a856747aee23a34276fa101a7a157ea81e76394fbaf80b97dcf2f2'; \
 			;; \
 		'i386') \
 			url='https://downloads.python.org/pypy/pypy3.7-v7.3.8-linux32.tar.bz2'; \

--- a/3.7/buster/Dockerfile
+++ b/3.7/buster/Dockerfile
@@ -22,6 +22,7 @@ ENV LANG C.UTF-8
 # ensure local pypy3 is preferred over distribution pypy3
 ENV PATH /opt/pypy/bin:$PATH
 
+# Python 3.7.12
 ENV PYPY_VERSION 7.3.8
 
 RUN set -eux; \
@@ -33,8 +34,8 @@ RUN set -eux; \
 			sha256='409085db79a6d90bfcf4f576dca1538498e65937acfbe03bd4909bdc262ff378'; \
 			;; \
 		'arm64') \
-			url='https://downloads.python.org/pypy/pypy3.7-v7.3.8-aarch64.tar.bz2'; \
-			sha256='4fb2f8281f3aaca72e6fe62ecc5fc054fcc79cd061ca3e0eea730f7d82d610d4'; \
+			url='https://downloads.python.org/pypy/pypy3.7-v7.3.8-aarch64-portable.tar.bz2'; \
+			sha256='639c76f128a856747aee23a34276fa101a7a157ea81e76394fbaf80b97dcf2f2'; \
 			;; \
 		'i386') \
 			url='https://downloads.python.org/pypy/pypy3.7-v7.3.8-linux32.tar.bz2'; \

--- a/3.7/slim-bullseye/Dockerfile
+++ b/3.7/slim-bullseye/Dockerfile
@@ -18,6 +18,7 @@ ENV LANG C.UTF-8
 # ensure local pypy3 is preferred over distribution pypy3
 ENV PATH /opt/pypy/bin:$PATH
 
+# Python 3.7.12
 ENV PYPY_VERSION 7.3.8
 
 RUN set -eux; \
@@ -29,8 +30,8 @@ RUN set -eux; \
 			sha256='409085db79a6d90bfcf4f576dca1538498e65937acfbe03bd4909bdc262ff378'; \
 			;; \
 		'arm64') \
-			url='https://downloads.python.org/pypy/pypy3.7-v7.3.8-aarch64.tar.bz2'; \
-			sha256='4fb2f8281f3aaca72e6fe62ecc5fc054fcc79cd061ca3e0eea730f7d82d610d4'; \
+			url='https://downloads.python.org/pypy/pypy3.7-v7.3.8-aarch64-portable.tar.bz2'; \
+			sha256='639c76f128a856747aee23a34276fa101a7a157ea81e76394fbaf80b97dcf2f2'; \
 			;; \
 		'i386') \
 			url='https://downloads.python.org/pypy/pypy3.7-v7.3.8-linux32.tar.bz2'; \

--- a/3.7/slim-buster/Dockerfile
+++ b/3.7/slim-buster/Dockerfile
@@ -18,6 +18,7 @@ ENV LANG C.UTF-8
 # ensure local pypy3 is preferred over distribution pypy3
 ENV PATH /opt/pypy/bin:$PATH
 
+# Python 3.7.12
 ENV PYPY_VERSION 7.3.8
 
 RUN set -eux; \
@@ -29,8 +30,8 @@ RUN set -eux; \
 			sha256='409085db79a6d90bfcf4f576dca1538498e65937acfbe03bd4909bdc262ff378'; \
 			;; \
 		'arm64') \
-			url='https://downloads.python.org/pypy/pypy3.7-v7.3.8-aarch64.tar.bz2'; \
-			sha256='4fb2f8281f3aaca72e6fe62ecc5fc054fcc79cd061ca3e0eea730f7d82d610d4'; \
+			url='https://downloads.python.org/pypy/pypy3.7-v7.3.8-aarch64-portable.tar.bz2'; \
+			sha256='639c76f128a856747aee23a34276fa101a7a157ea81e76394fbaf80b97dcf2f2'; \
 			;; \
 		'i386') \
 			url='https://downloads.python.org/pypy/pypy3.7-v7.3.8-linux32.tar.bz2'; \

--- a/3.7/windows/windowsservercore-1809/Dockerfile
+++ b/3.7/windows/windowsservercore-1809/Dockerfile
@@ -44,6 +44,7 @@ RUN $url = 'https://download.microsoft.com/download/6/A/A/6AA4EDFF-645B-48C5-81C
 	\
 	Write-Host 'Complete.'
 
+# Python 3.7.12
 ENV PYPY_VERSION 7.3.8
 
 RUN $url = 'https://downloads.python.org/pypy/pypy3.7-v7.3.8-win64.zip'; \

--- a/3.8/bullseye/Dockerfile
+++ b/3.8/bullseye/Dockerfile
@@ -22,6 +22,7 @@ ENV LANG C.UTF-8
 # ensure local pypy3 is preferred over distribution pypy3
 ENV PATH /opt/pypy/bin:$PATH
 
+# Python 3.8.12
 ENV PYPY_VERSION 7.3.8
 
 RUN set -eux; \
@@ -33,8 +34,8 @@ RUN set -eux; \
 			sha256='089f8e3e357d6130815964ddd3507c13bd53e4976ccf0a89b5c36a9a6775a188'; \
 			;; \
 		'arm64') \
-			url='https://downloads.python.org/pypy/pypy3.8-v7.3.8-aarch64.tar.bz2'; \
-			sha256='fe41df391f87239925e573e195e631a9d03d37f471eb1479790ee13ca47a28af'; \
+			url='https://downloads.python.org/pypy/pypy3.8-v7.3.8-aarch64-portable.tar.bz2'; \
+			sha256='0210536e9f1841ba283c13b04783394050837bb3e6f4091c9f1bd9c7f2b94b55'; \
 			;; \
 		'i386') \
 			url='https://downloads.python.org/pypy/pypy3.8-v7.3.8-linux32.tar.bz2'; \

--- a/3.8/buster/Dockerfile
+++ b/3.8/buster/Dockerfile
@@ -22,6 +22,7 @@ ENV LANG C.UTF-8
 # ensure local pypy3 is preferred over distribution pypy3
 ENV PATH /opt/pypy/bin:$PATH
 
+# Python 3.8.12
 ENV PYPY_VERSION 7.3.8
 
 RUN set -eux; \
@@ -33,8 +34,8 @@ RUN set -eux; \
 			sha256='089f8e3e357d6130815964ddd3507c13bd53e4976ccf0a89b5c36a9a6775a188'; \
 			;; \
 		'arm64') \
-			url='https://downloads.python.org/pypy/pypy3.8-v7.3.8-aarch64.tar.bz2'; \
-			sha256='fe41df391f87239925e573e195e631a9d03d37f471eb1479790ee13ca47a28af'; \
+			url='https://downloads.python.org/pypy/pypy3.8-v7.3.8-aarch64-portable.tar.bz2'; \
+			sha256='0210536e9f1841ba283c13b04783394050837bb3e6f4091c9f1bd9c7f2b94b55'; \
 			;; \
 		'i386') \
 			url='https://downloads.python.org/pypy/pypy3.8-v7.3.8-linux32.tar.bz2'; \

--- a/3.8/slim-bullseye/Dockerfile
+++ b/3.8/slim-bullseye/Dockerfile
@@ -18,6 +18,7 @@ ENV LANG C.UTF-8
 # ensure local pypy3 is preferred over distribution pypy3
 ENV PATH /opt/pypy/bin:$PATH
 
+# Python 3.8.12
 ENV PYPY_VERSION 7.3.8
 
 RUN set -eux; \
@@ -29,8 +30,8 @@ RUN set -eux; \
 			sha256='089f8e3e357d6130815964ddd3507c13bd53e4976ccf0a89b5c36a9a6775a188'; \
 			;; \
 		'arm64') \
-			url='https://downloads.python.org/pypy/pypy3.8-v7.3.8-aarch64.tar.bz2'; \
-			sha256='fe41df391f87239925e573e195e631a9d03d37f471eb1479790ee13ca47a28af'; \
+			url='https://downloads.python.org/pypy/pypy3.8-v7.3.8-aarch64-portable.tar.bz2'; \
+			sha256='0210536e9f1841ba283c13b04783394050837bb3e6f4091c9f1bd9c7f2b94b55'; \
 			;; \
 		'i386') \
 			url='https://downloads.python.org/pypy/pypy3.8-v7.3.8-linux32.tar.bz2'; \

--- a/3.8/slim-buster/Dockerfile
+++ b/3.8/slim-buster/Dockerfile
@@ -18,6 +18,7 @@ ENV LANG C.UTF-8
 # ensure local pypy3 is preferred over distribution pypy3
 ENV PATH /opt/pypy/bin:$PATH
 
+# Python 3.8.12
 ENV PYPY_VERSION 7.3.8
 
 RUN set -eux; \
@@ -29,8 +30,8 @@ RUN set -eux; \
 			sha256='089f8e3e357d6130815964ddd3507c13bd53e4976ccf0a89b5c36a9a6775a188'; \
 			;; \
 		'arm64') \
-			url='https://downloads.python.org/pypy/pypy3.8-v7.3.8-aarch64.tar.bz2'; \
-			sha256='fe41df391f87239925e573e195e631a9d03d37f471eb1479790ee13ca47a28af'; \
+			url='https://downloads.python.org/pypy/pypy3.8-v7.3.8-aarch64-portable.tar.bz2'; \
+			sha256='0210536e9f1841ba283c13b04783394050837bb3e6f4091c9f1bd9c7f2b94b55'; \
 			;; \
 		'i386') \
 			url='https://downloads.python.org/pypy/pypy3.8-v7.3.8-linux32.tar.bz2'; \

--- a/3.8/windows/windowsservercore-1809/Dockerfile
+++ b/3.8/windows/windowsservercore-1809/Dockerfile
@@ -44,6 +44,7 @@ RUN $url = 'https://download.microsoft.com/download/6/A/A/6AA4EDFF-645B-48C5-81C
 	\
 	Write-Host 'Complete.'
 
+# Python 3.8.12
 ENV PYPY_VERSION 7.3.8
 
 RUN $url = 'https://downloads.python.org/pypy/pypy3.8-v7.3.8-win64.zip'; \

--- a/3.9/bullseye/Dockerfile
+++ b/3.9/bullseye/Dockerfile
@@ -22,6 +22,7 @@ ENV LANG C.UTF-8
 # ensure local pypy3 is preferred over distribution pypy3
 ENV PATH /opt/pypy/bin:$PATH
 
+# Python 3.9.10
 ENV PYPY_VERSION 7.3.8
 
 RUN set -eux; \
@@ -33,8 +34,8 @@ RUN set -eux; \
 			sha256='129a055032bba700cd1d0acacab3659cf6b7180e25b1b2f730e792f06d5b3010'; \
 			;; \
 		'arm64') \
-			url='https://downloads.python.org/pypy/pypy3.9-v7.3.8-aarch64.tar.bz2'; \
-			sha256='89d7ee12a8c416e83fae80af82482531fc6502321e75e5b7a0cc01d756ee5f0e'; \
+			url='https://downloads.python.org/pypy/pypy3.9-v7.3.8-aarch64-portable.tar.bz2'; \
+			sha256='b7282bc4484bceae5bc4cc04e05ee4faf51cb624c8fc7a69d92e5fdf0d0c96aa'; \
 			;; \
 		'i386') \
 			url='https://downloads.python.org/pypy/pypy3.9-v7.3.8-linux32.tar.bz2'; \

--- a/3.9/buster/Dockerfile
+++ b/3.9/buster/Dockerfile
@@ -22,6 +22,7 @@ ENV LANG C.UTF-8
 # ensure local pypy3 is preferred over distribution pypy3
 ENV PATH /opt/pypy/bin:$PATH
 
+# Python 3.9.10
 ENV PYPY_VERSION 7.3.8
 
 RUN set -eux; \
@@ -33,8 +34,8 @@ RUN set -eux; \
 			sha256='129a055032bba700cd1d0acacab3659cf6b7180e25b1b2f730e792f06d5b3010'; \
 			;; \
 		'arm64') \
-			url='https://downloads.python.org/pypy/pypy3.9-v7.3.8-aarch64.tar.bz2'; \
-			sha256='89d7ee12a8c416e83fae80af82482531fc6502321e75e5b7a0cc01d756ee5f0e'; \
+			url='https://downloads.python.org/pypy/pypy3.9-v7.3.8-aarch64-portable.tar.bz2'; \
+			sha256='b7282bc4484bceae5bc4cc04e05ee4faf51cb624c8fc7a69d92e5fdf0d0c96aa'; \
 			;; \
 		'i386') \
 			url='https://downloads.python.org/pypy/pypy3.9-v7.3.8-linux32.tar.bz2'; \

--- a/3.9/slim-bullseye/Dockerfile
+++ b/3.9/slim-bullseye/Dockerfile
@@ -18,6 +18,7 @@ ENV LANG C.UTF-8
 # ensure local pypy3 is preferred over distribution pypy3
 ENV PATH /opt/pypy/bin:$PATH
 
+# Python 3.9.10
 ENV PYPY_VERSION 7.3.8
 
 RUN set -eux; \
@@ -29,8 +30,8 @@ RUN set -eux; \
 			sha256='129a055032bba700cd1d0acacab3659cf6b7180e25b1b2f730e792f06d5b3010'; \
 			;; \
 		'arm64') \
-			url='https://downloads.python.org/pypy/pypy3.9-v7.3.8-aarch64.tar.bz2'; \
-			sha256='89d7ee12a8c416e83fae80af82482531fc6502321e75e5b7a0cc01d756ee5f0e'; \
+			url='https://downloads.python.org/pypy/pypy3.9-v7.3.8-aarch64-portable.tar.bz2'; \
+			sha256='b7282bc4484bceae5bc4cc04e05ee4faf51cb624c8fc7a69d92e5fdf0d0c96aa'; \
 			;; \
 		'i386') \
 			url='https://downloads.python.org/pypy/pypy3.9-v7.3.8-linux32.tar.bz2'; \

--- a/3.9/slim-buster/Dockerfile
+++ b/3.9/slim-buster/Dockerfile
@@ -18,6 +18,7 @@ ENV LANG C.UTF-8
 # ensure local pypy3 is preferred over distribution pypy3
 ENV PATH /opt/pypy/bin:$PATH
 
+# Python 3.9.10
 ENV PYPY_VERSION 7.3.8
 
 RUN set -eux; \
@@ -29,8 +30,8 @@ RUN set -eux; \
 			sha256='129a055032bba700cd1d0acacab3659cf6b7180e25b1b2f730e792f06d5b3010'; \
 			;; \
 		'arm64') \
-			url='https://downloads.python.org/pypy/pypy3.9-v7.3.8-aarch64.tar.bz2'; \
-			sha256='89d7ee12a8c416e83fae80af82482531fc6502321e75e5b7a0cc01d756ee5f0e'; \
+			url='https://downloads.python.org/pypy/pypy3.9-v7.3.8-aarch64-portable.tar.bz2'; \
+			sha256='b7282bc4484bceae5bc4cc04e05ee4faf51cb624c8fc7a69d92e5fdf0d0c96aa'; \
 			;; \
 		'i386') \
 			url='https://downloads.python.org/pypy/pypy3.9-v7.3.8-linux32.tar.bz2'; \

--- a/3.9/windows/windowsservercore-1809/Dockerfile
+++ b/3.9/windows/windowsservercore-1809/Dockerfile
@@ -44,6 +44,7 @@ RUN $url = 'https://download.microsoft.com/download/6/A/A/6AA4EDFF-645B-48C5-81C
 	\
 	Write-Host 'Complete.'
 
+# Python 3.9.10
 ENV PYPY_VERSION 7.3.8
 
 RUN $url = 'https://downloads.python.org/pypy/pypy3.9-v7.3.8-win64.zip'; \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -53,6 +53,7 @@ ENV LANG C.UTF-8
 # ensure local {{ cmd }} is preferred over distribution {{ cmd }}
 ENV PATH /opt/pypy/bin:$PATH
 
+# Python {{ .python.version }}
 ENV PYPY_VERSION {{ .version }}
 
 RUN set -eux; \
@@ -62,7 +63,7 @@ RUN set -eux; \
 {{
 	[
 		.arches | to_entries[]
-		| select(.key | startswith("windows-") | not)
+		| select(.key | index("-") | not)
 		| .key as $bashbrewArch
 		| (
 			{

--- a/Dockerfile-windows-servercore.template
+++ b/Dockerfile-windows-servercore.template
@@ -45,6 +45,7 @@ RUN $url = 'https://download.microsoft.com/download/6/A/A/6AA4EDFF-645B-48C5-81C
 	\
 	Write-Host 'Complete.'
 
+# Python {{ .python.version }}
 ENV PYPY_VERSION {{ .version }}
 
 RUN $url = '{{ .arches["windows-amd64"].url }}'; \

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -159,8 +159,6 @@ for version; do
 					# "pypy3: error while loading shared libraries: libffi.so.6: cannot open shared object file: No such file or directory"
 					variantArches="$(sed -r -e '/^s390x$/d' <<<"$variantArches")"
 				fi
-				# arm64 has the libffi.so.6 issue plus "pypy: error while loading shared libraries: libtinfow.so.6: cannot open shared object file: No such file or directory" (so everything fails)
-				variantArches="$(sed -r -e '/^arm64v8$/d' <<<"$variantArches")"
 				;;
 		esac
 

--- a/versions.json
+++ b/versions.json
@@ -6,12 +6,20 @@
         "url": "https://downloads.python.org/pypy/pypy2.7-v7.3.8-linux64.tar.bz2"
       },
       "arm64v8": {
-        "sha256": "ca1f8d3146c83002ee97615906b0930e821297dcce3063b5b28933a0690ef298",
-        "url": "https://downloads.python.org/pypy/pypy2.7-v7.3.8-aarch64.tar.bz2"
+        "sha256": "b5edfc995d83feea8b4c8aeffccb89753b4b182f076126550bd07cc35faa6208",
+        "url": "https://downloads.python.org/pypy/pypy2.7-v7.3.8-aarch64-portable.tar.bz2"
+      },
+      "darwin-amd64": {
+        "sha256": "e5c1ff39ad9916ea23e3deb8012fe42367b6b19284cf13b1a1ea2b2f53a43add",
+        "url": "https://downloads.python.org/pypy/pypy2.7-v7.3.8-osx64.tar.bz2"
       },
       "i386": {
         "sha256": "7c84f173bbcd73d0eb10909259d11b5cc253d4c6ea4492e6da8f2532df9b3da5",
         "url": "https://downloads.python.org/pypy/pypy2.7-v7.3.8-linux32.tar.bz2"
+      },
+      "s390x": {
+        "sha256": "b4ae4e708ba84602d976ad6ae391ef2eef4b1896d831b8f2b2ec69927dd92014",
+        "url": "https://downloads.python.org/pypy/pypy2.7-v7.3.8-s390x.tar.bz2"
       },
       "windows-amd64": {
         "sha256": "806a29a6c5550b1e669d8870683d3379138d3d43eb1e07bdf26d65a0691265f2",
@@ -22,6 +30,10 @@
       "sha256": "95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218",
       "url": "https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py",
       "version": "3843bff3a0a61da5b63ea0b7d34794c5c51a2f11"
+    },
+    "python": {
+      "major": "2.7",
+      "version": "2.7.18"
     },
     "variants": [
       "bullseye",
@@ -39,8 +51,12 @@
         "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.8-linux64.tar.bz2"
       },
       "arm64v8": {
-        "sha256": "4fb2f8281f3aaca72e6fe62ecc5fc054fcc79cd061ca3e0eea730f7d82d610d4",
-        "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.8-aarch64.tar.bz2"
+        "sha256": "639c76f128a856747aee23a34276fa101a7a157ea81e76394fbaf80b97dcf2f2",
+        "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.8-aarch64-portable.tar.bz2"
+      },
+      "darwin-amd64": {
+        "sha256": "76b8eef5b059a7e478f525615482d2a6e9feb83375e3f63c16381d80521a693f",
+        "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.8-osx64.tar.bz2"
       },
       "i386": {
         "sha256": "38429ec6ea1aca391821ee4fbda7358ae86de4600146643f2af2fe2c085af839",
@@ -60,6 +76,10 @@
       "url": "https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py",
       "version": "3843bff3a0a61da5b63ea0b7d34794c5c51a2f11"
     },
+    "python": {
+      "major": "3.7",
+      "version": "3.7.12"
+    },
     "variants": [
       "bullseye",
       "slim-bullseye",
@@ -76,8 +96,12 @@
         "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.8-linux64.tar.bz2"
       },
       "arm64v8": {
-        "sha256": "fe41df391f87239925e573e195e631a9d03d37f471eb1479790ee13ca47a28af",
-        "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.8-aarch64.tar.bz2"
+        "sha256": "0210536e9f1841ba283c13b04783394050837bb3e6f4091c9f1bd9c7f2b94b55",
+        "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.8-aarch64-portable.tar.bz2"
+      },
+      "darwin-amd64": {
+        "sha256": "de1b283ff112d76395c0162a1cf11528e192bdc230ee3f1b237f7694c7518dee",
+        "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.8-osx64.tar.bz2"
       },
       "i386": {
         "sha256": "bea4b275decd492af6462157d293dd6fcf08a949859f8aec0959537b40afd032",
@@ -97,6 +121,10 @@
       "url": "https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py",
       "version": "3843bff3a0a61da5b63ea0b7d34794c5c51a2f11"
     },
+    "python": {
+      "major": "3.8",
+      "version": "3.8.12"
+    },
     "variants": [
       "bullseye",
       "slim-bullseye",
@@ -113,8 +141,12 @@
         "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.8-linux64.tar.bz2"
       },
       "arm64v8": {
-        "sha256": "89d7ee12a8c416e83fae80af82482531fc6502321e75e5b7a0cc01d756ee5f0e",
-        "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.8-aarch64.tar.bz2"
+        "sha256": "b7282bc4484bceae5bc4cc04e05ee4faf51cb624c8fc7a69d92e5fdf0d0c96aa",
+        "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.8-aarch64-portable.tar.bz2"
+      },
+      "darwin-amd64": {
+        "sha256": "95bd88ac8d6372cd5b7b5393de7b7d5c615a0c6e42fdb1eb67f2d2d510965aee",
+        "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.8-osx64.tar.bz2"
       },
       "i386": {
         "sha256": "a0d18e4e73cc655eb02354759178b8fb161d3e53b64297d05e2fff91f7cf862d",
@@ -133,6 +165,10 @@
       "sha256": "95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218",
       "url": "https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py",
       "version": "3843bff3a0a61da5b63ea0b7d34794c5c51a2f11"
+    },
+    "python": {
+      "major": "3.9",
+      "version": "3.9.10"
     },
     "variants": [
       "bullseye",

--- a/versions.sh
+++ b/versions.sh
@@ -1,25 +1,56 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-# see https://downloads.python.org/pypy/
-declare -A pypyArches=(
-	['amd64']='linux64'
-	['arm32v5']='linux-armel'
-	['arm32v7']='linux-armhf-raring'
-	['arm64v8']='aarch64'
-	['i386']='linux32'
-	['windows-amd64']='win64'
+# https://downloads.python.org/pypy/versions.json
+# https://www.pypy.org/download.html
+# https://downloads.python.org/pypy/
+allVersions="$(wget -qO- 'https://downloads.python.org/pypy/versions.json' | jq -c '
+	map(
+		select(.stable and .latest_pypy) # do some minor pre-filtering to cut down the list of things to sort through
+		| {
+			version: .pypy_version,
+			python: {
+				version: .python_version,
+				major: (.python_version | split(".")[0:2] | join(".")), # convert "x.y.z" into "x.y"
+			},
+			arches: (
+				.files
+				| map(
+					{
+						"darwin": "darwin",
+						"linux": "linux",
+						"win64": "windows",
+					}[.platform] as $os
+					| select($os)
+					| (
+						if $os != "linux" then
+							$os + "-"
+						else "" end + {
+							"aarch64": "arm64v8",
+							"i686": "i386",
+							"s390x": "s390x",
+							"x64": "amd64",
+						}[.arch]
+					) as $arch
+					| select($arch)
+					| { ($arch): { url: .download_url } }
+				) | add
+			),
+		}
+	)
+')"
 
-	# see https://foss.heptapod.net/pypy/pypy/-/issues/2646 for some s390x/ppc64le caveats (mitigated in 3.x via https://github.com/docker-library/pypy/issues/24#issuecomment-476873691)
-	['ppc64le']='ppc64le'
-	['s390x']='s390x'
-)
+fullVersion="$(jq <<<"$allVersions" -r '.[0].version')"
+export fullVersion
+
+thisVersion="$(jq <<<"$allVersions" -c 'map(select(.version == env.fullVersion) | { (.python.major): . }) | add')"
 
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
 versions=( "$@" )
 if [ ${#versions[@]} -eq 0 ]; then
-	versions=( */ )
+	shell="$(jq <<<"$thisVersion" -r 'keys_unsorted | map(@sh) | join(" ")')"
+	eval "versions=( $shell )"
 	json='{}'
 else
 	json="$(< versions.json)"
@@ -27,18 +58,6 @@ fi
 versions=( "${versions[@]%/}" )
 
 sha256s="$(curl -fsSL --compressed 'https://www.pypy.org/checksums.html')"
-pypy_tarball() {
-	local pypy="$1"; shift
-	local fullVersion="$1"; shift
-	local arch="$1"; shift
-
-	local ext='tar.bz2'
-	if [ "$arch" = 'win64' ]; then
-		ext='zip'
-	fi
-
-	echo "pypy$pypy-v$fullVersion-$arch.$ext"
-}
 scrape_sha256() {
 	local tarball="$1"; shift
 
@@ -52,43 +71,36 @@ scrape_sha256() {
 		| cut -d' ' -f1
 }
 
-downloads="$(curl -fsSL --compressed 'https://downloads.python.org/pypy/')"
-
 for version in "${versions[@]}"; do
 	export version
 
-	IFS=$'\n'
-	tryVersions=( $(
-		sed -rn 's/^.*pypy'"$version"'-v([0-9.]+(-alpha[0-9]*)?)-'"${pypyArches['amd64']}"'[.]tar[.]bz2.*$/\1/gp' <<<"$downloads" \
-			| sort -rV
-	) )
-	unset IFS
+	echo "$version: $fullVersion"
 
-	fullVersion=
-	pypyArch="${pypyArches['amd64']}"
-	tarball=
-	sha256=
-	for tryVersion in "${tryVersions[@]}"; do
-		if tarball="$(pypy_tarball "$version" "$tryVersion" "$pypyArch")" && sha256="$(scrape_sha256 "$tarball")" && [ -n "$sha256" ]; then
-			fullVersion="$tryVersion"
-			break
+	doc="$(jq <<<"$thisVersion" -c '.[env.version]')"
+
+	shell="$(jq <<<"$doc" -r '
+		.arches
+		| to_entries
+		| map(
+			"[" + (.key | @sh) + "]=" + (.value.url | @sh)
+		)
+		| join(" ")
+	')"
+	eval "declare -A arches=( $shell )"
+	for arch in "${!arches[@]}"; do
+		url="${arches[$arch]}"
+		tarball="$(basename "$url")"
+		if ! sha256="$(scrape_sha256 "$tarball")"; then
+			echo >&2 "error: failed to find sha256 for '$version' on '$arch' ('$tarball')"
+			echo >&2 "  URL: $url"
+			exit 1
 		fi
+		export arch sha256
+		doc="$(jq <<<"$doc" -c '.arches[env.arch].sha256 = env.sha256')"
 	done
-	if [ -z "$fullVersion" ]; then
-		echo >&2 "error: cannot find suitable release for '$version'"
-		exit 1
-	fi
 
-	export fullVersion tarball sha256
-	doc="$(jq -nc '
-		{
-			version: env.fullVersion,
-			arches: {
-				amd64: {
-					sha256: env.sha256,
-					url: ("https://downloads.python.org/pypy/" + env.tarball),
-				},
-			},
+	json="$(jq <<<"$json" -c --argjson doc "$doc" '
+		.[env.version] = $doc + {
 			"get-pip": {
 				# https://github.com/pypa/get-pip/releases/tag/20.3.4 (the last release to support Python 2)
 				version: "3843bff3a0a61da5b63ea0b7d34794c5c51a2f11",
@@ -96,58 +108,6 @@ for version in "${versions[@]}"; do
 				sha256: "95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218",
 				# TODO use a newer commit for Python 3
 			},
-		}
-	')"
-
-	# if our current version is newer than the version we just scraped, this must be a fluke/flake (https://github.com/docker-library/official-images/pull/6163)
-	if \
-		currentVersion="$(
-			jq -r '.[env.version].version // ""' versions.json 2>/dev/null
-		)" \
-		&& [ -n "$currentVersion" ] \
-		&& [ "$currentVersion" != "$fullVersion" ] \
-		&& newVersion="$(
-			{
-				echo "$fullVersion"
-				echo "$currentVersion"
-			} | sort -rV | head -1
-		)" \
-		&& [ "$newVersion" = "$currentVersion" ] \
-	; then
-		echo >&2 "error: scraped version ($fullVersion) is older than our current version ($currentVersion)!"
-		echo >&2 "  cowardly bailing to avoid unnecessary churn"
-		exit 1
-	fi
-
-	echo "$version: $fullVersion"
-
-	for bashbrewArch in "${!pypyArches[@]}"; do
-		case "$version/$bashbrewArch" in
-			*/amd64)
-				# we already collected the amd64 sha256 above
-				continue
-				;;
-
-			2.7/s390x | 2.7/ppc64le)
-				echo >&2 "warning: skipping $version on $bashbrewArch; https://foss.heptapod.net/pypy/pypy/-/issues/2646"
-				continue
-				;;
-		esac
-
-		pypyArch="${pypyArches["$bashbrewArch"]}"
-		if tarball="$(pypy_tarball "$version" "$fullVersion" "$pypyArch")" && sha256="$(scrape_sha256 "$tarball")" && [ -n "$sha256" ]; then
-			export bashbrewArch tarball sha256
-			doc="$(jq <<<"$doc" -c '
-				.arches[env.bashbrewArch] = {
-					sha256: env.sha256,
-					url: ("https://downloads.python.org/pypy/" + env.tarball),
-				}
-			')"
-		fi
-	done
-
-	json="$(jq <<<"$json" -c --argjson doc "$doc" '
-		.[env.version] = $doc + {
 			variants: [
 				(
 					"bullseye",


### PR DESCRIPTION
Getting version/URL information from https://downloads.python.org/pypy/versions.json should give us much more accurate and reliable versioning information than scraping HTML does.

This _also_ gets us the correct adjusted URL for the current `aarch64` releases that allow us to bring back `arm64v8` support! (https://github.com/docker-library/pypy/pull/69#issuecomment-1061057221) :tada:

Thanks @mattip!!