### PR TITLE
Update generic/default aliases to bookworm

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -6,7 +6,7 @@ declare -A aliases=(
 	['2.7']='2'
 )
 
-defaultDebianSuite='bullseye'
+defaultDebianSuite='bookworm'
 
 self="$(basename "$BASH_SOURCE")"
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"


### PR DESCRIPTION
We should've done this back in https://github.com/docker-library/pypy/pull/77 (9a9efe06150ce464f288617c8e3ec765bb93250e), but missed it. 🙈