### PR TITLE
Verify the published Python compatibility version

### DIFF
--- a/2.7/bookworm/Dockerfile
+++ b/2.7/bookworm/Dockerfile
@@ -66,6 +66,9 @@ RUN set -eux; \
 	\
 # smoke test
 	pypy --version; \
+# verify (C)Python version is accurate
+	pypyPython="$(pypy -c 'import sys; print(".".join(map(str, sys.version_info[0:3])))')"; \
+	[ "$pypyPython" = '2.7.18' ]; \
 	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \

--- a/2.7/bullseye/Dockerfile
+++ b/2.7/bullseye/Dockerfile
@@ -66,6 +66,9 @@ RUN set -eux; \
 	\
 # smoke test
 	pypy --version; \
+# verify (C)Python version is accurate
+	pypyPython="$(pypy -c 'import sys; print(".".join(map(str, sys.version_info[0:3])))')"; \
+	[ "$pypyPython" = '2.7.18' ]; \
 	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \

--- a/2.7/slim-bookworm/Dockerfile
+++ b/2.7/slim-bookworm/Dockerfile
@@ -64,6 +64,9 @@ RUN set -eux; \
 	\
 # smoke test
 	pypy --version; \
+# verify (C)Python version is accurate
+	pypyPython="$(pypy -c 'import sys; print(".".join(map(str, sys.version_info[0:3])))')"; \
+	[ "$pypyPython" = '2.7.18' ]; \
 	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \

--- a/2.7/slim-bullseye/Dockerfile
+++ b/2.7/slim-bullseye/Dockerfile
@@ -64,6 +64,9 @@ RUN set -eux; \
 	\
 # smoke test
 	pypy --version; \
+# verify (C)Python version is accurate
+	pypyPython="$(pypy -c 'import sys; print(".".join(map(str, sys.version_info[0:3])))')"; \
+	[ "$pypyPython" = '2.7.18' ]; \
 	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \

--- a/2.7/windows/windowsservercore-1809/Dockerfile
+++ b/2.7/windows/windowsservercore-1809/Dockerfile
@@ -72,6 +72,12 @@ RUN $url = 'https://downloads.python.org/pypy/pypy2.7-v7.3.19-win64.zip'; \
 	\
 	Write-Host 'Verifying install ("pypy --version") ...'; \
 	pypy --version; \
+# double quotes in Docker WCOW + PowerShell is something that's totally and completely unsupported thanks to cmd.exe: https://github.com/docker-library/pypy/pull/88#issuecomment-2699167808
+	$pypyPython = pypy -c 'import sys; print(''.''.join(map(str, sys.version_info[0:3])))'; \
+	if ($pypyPython -ne '2.7.18') { \
+		Write-Host ('Python version mismatch: {0} vs {1}' -f $pypyPython, '2.7.18'); \
+		exit 1; \
+	}; \
 	\
 	Write-Host 'Cleanup install ...'; \
 	Get-ChildItem \

--- a/2.7/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/2.7/windows/windowsservercore-ltsc2022/Dockerfile
@@ -72,6 +72,12 @@ RUN $url = 'https://downloads.python.org/pypy/pypy2.7-v7.3.19-win64.zip'; \
 	\
 	Write-Host 'Verifying install ("pypy --version") ...'; \
 	pypy --version; \
+# double quotes in Docker WCOW + PowerShell is something that's totally and completely unsupported thanks to cmd.exe: https://github.com/docker-library/pypy/pull/88#issuecomment-2699167808
+	$pypyPython = pypy -c 'import sys; print(''.''.join(map(str, sys.version_info[0:3])))'; \
+	if ($pypyPython -ne '2.7.18') { \
+		Write-Host ('Python version mismatch: {0} vs {1}' -f $pypyPython, '2.7.18'); \
+		exit 1; \
+	}; \
 	\
 	Write-Host 'Cleanup install ...'; \
 	Get-ChildItem \

--- a/2.7/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/2.7/windows/windowsservercore-ltsc2025/Dockerfile
@@ -72,6 +72,12 @@ RUN $url = 'https://downloads.python.org/pypy/pypy2.7-v7.3.19-win64.zip'; \
 	\
 	Write-Host 'Verifying install ("pypy --version") ...'; \
 	pypy --version; \
+# double quotes in Docker WCOW + PowerShell is something that's totally and completely unsupported thanks to cmd.exe: https://github.com/docker-library/pypy/pull/88#issuecomment-2699167808
+	$pypyPython = pypy -c 'import sys; print(''.''.join(map(str, sys.version_info[0:3])))'; \
+	if ($pypyPython -ne '2.7.18') { \
+		Write-Host ('Python version mismatch: {0} vs {1}' -f $pypyPython, '2.7.18'); \
+		exit 1; \
+	}; \
 	\
 	Write-Host 'Cleanup install ...'; \
 	Get-ChildItem \

--- a/3.10/bookworm/Dockerfile
+++ b/3.10/bookworm/Dockerfile
@@ -66,6 +66,9 @@ RUN set -eux; \
 	\
 # smoke test
 	pypy3 --version; \
+# verify (C)Python version is accurate
+	pypyPython="$(pypy3 -c 'import sys; print(".".join(map(str, sys.version_info[0:3])))')"; \
+	[ "$pypyPython" = '3.10.16' ]; \
 	\
 	cd /opt/pypy/lib/pypy3.10; \
 # on pypy3, rebuild gdbm ffi bits for compatibility with Debian Stretch+

--- a/3.10/bullseye/Dockerfile
+++ b/3.10/bullseye/Dockerfile
@@ -66,6 +66,9 @@ RUN set -eux; \
 	\
 # smoke test
 	pypy3 --version; \
+# verify (C)Python version is accurate
+	pypyPython="$(pypy3 -c 'import sys; print(".".join(map(str, sys.version_info[0:3])))')"; \
+	[ "$pypyPython" = '3.10.16' ]; \
 	\
 	cd /opt/pypy/lib/pypy3.10; \
 # on pypy3, rebuild gdbm ffi bits for compatibility with Debian Stretch+

--- a/3.10/slim-bookworm/Dockerfile
+++ b/3.10/slim-bookworm/Dockerfile
@@ -64,6 +64,9 @@ RUN set -eux; \
 	\
 # smoke test
 	pypy3 --version; \
+# verify (C)Python version is accurate
+	pypyPython="$(pypy3 -c 'import sys; print(".".join(map(str, sys.version_info[0:3])))')"; \
+	[ "$pypyPython" = '3.10.16' ]; \
 	\
 	cd /opt/pypy/lib/pypy3.10; \
 # on pypy3, rebuild gdbm ffi bits for compatibility with Debian Stretch+

--- a/3.10/slim-bullseye/Dockerfile
+++ b/3.10/slim-bullseye/Dockerfile
@@ -64,6 +64,9 @@ RUN set -eux; \
 	\
 # smoke test
 	pypy3 --version; \
+# verify (C)Python version is accurate
+	pypyPython="$(pypy3 -c 'import sys; print(".".join(map(str, sys.version_info[0:3])))')"; \
+	[ "$pypyPython" = '3.10.16' ]; \
 	\
 	cd /opt/pypy/lib/pypy3.10; \
 # on pypy3, rebuild gdbm ffi bits for compatibility with Debian Stretch+

--- a/3.10/windows/windowsservercore-1809/Dockerfile
+++ b/3.10/windows/windowsservercore-1809/Dockerfile
@@ -69,6 +69,12 @@ RUN $url = 'https://downloads.python.org/pypy/pypy3.10-v7.3.19-win64.zip'; \
 	\
 	Write-Host 'Verifying install ("pypy --version") ...'; \
 	pypy --version; \
+# double quotes in Docker WCOW + PowerShell is something that's totally and completely unsupported thanks to cmd.exe: https://github.com/docker-library/pypy/pull/88#issuecomment-2699167808
+	$pypyPython = pypy -c 'import sys; print(''.''.join(map(str, sys.version_info[0:3])))'; \
+	if ($pypyPython -ne '3.10.16') { \
+		Write-Host ('Python version mismatch: {0} vs {1}' -f $pypyPython, '3.10.16'); \
+		exit 1; \
+	}; \
 	\
 	Write-Host 'Cleanup install ...'; \
 	Get-ChildItem \

--- a/3.10/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/3.10/windows/windowsservercore-ltsc2022/Dockerfile
@@ -69,6 +69,12 @@ RUN $url = 'https://downloads.python.org/pypy/pypy3.10-v7.3.19-win64.zip'; \
 	\
 	Write-Host 'Verifying install ("pypy --version") ...'; \
 	pypy --version; \
+# double quotes in Docker WCOW + PowerShell is something that's totally and completely unsupported thanks to cmd.exe: https://github.com/docker-library/pypy/pull/88#issuecomment-2699167808
+	$pypyPython = pypy -c 'import sys; print(''.''.join(map(str, sys.version_info[0:3])))'; \
+	if ($pypyPython -ne '3.10.16') { \
+		Write-Host ('Python version mismatch: {0} vs {1}' -f $pypyPython, '3.10.16'); \
+		exit 1; \
+	}; \
 	\
 	Write-Host 'Cleanup install ...'; \
 	Get-ChildItem \

--- a/3.10/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/3.10/windows/windowsservercore-ltsc2025/Dockerfile
@@ -69,6 +69,12 @@ RUN $url = 'https://downloads.python.org/pypy/pypy3.10-v7.3.19-win64.zip'; \
 	\
 	Write-Host 'Verifying install ("pypy --version") ...'; \
 	pypy --version; \
+# double quotes in Docker WCOW + PowerShell is something that's totally and completely unsupported thanks to cmd.exe: https://github.com/docker-library/pypy/pull/88#issuecomment-2699167808
+	$pypyPython = pypy -c 'import sys; print(''.''.join(map(str, sys.version_info[0:3])))'; \
+	if ($pypyPython -ne '3.10.16') { \
+		Write-Host ('Python version mismatch: {0} vs {1}' -f $pypyPython, '3.10.16'); \
+		exit 1; \
+	}; \
 	\
 	Write-Host 'Cleanup install ...'; \
 	Get-ChildItem \

--- a/3.11/bookworm/Dockerfile
+++ b/3.11/bookworm/Dockerfile
@@ -66,6 +66,9 @@ RUN set -eux; \
 	\
 # smoke test
 	pypy3 --version; \
+# verify (C)Python version is accurate
+	pypyPython="$(pypy3 -c 'import sys; print(".".join(map(str, sys.version_info[0:3])))')"; \
+	[ "$pypyPython" = '3.11.11' ]; \
 	\
 	cd /opt/pypy/lib/pypy3.11; \
 # on pypy3, rebuild gdbm ffi bits for compatibility with Debian Stretch+

--- a/3.11/slim-bookworm/Dockerfile
+++ b/3.11/slim-bookworm/Dockerfile
@@ -64,6 +64,9 @@ RUN set -eux; \
 	\
 # smoke test
 	pypy3 --version; \
+# verify (C)Python version is accurate
+	pypyPython="$(pypy3 -c 'import sys; print(".".join(map(str, sys.version_info[0:3])))')"; \
+	[ "$pypyPython" = '3.11.11' ]; \
 	\
 	cd /opt/pypy/lib/pypy3.11; \
 # on pypy3, rebuild gdbm ffi bits for compatibility with Debian Stretch+

--- a/3.11/windows/windowsservercore-1809/Dockerfile
+++ b/3.11/windows/windowsservercore-1809/Dockerfile
@@ -69,6 +69,12 @@ RUN $url = 'https://downloads.python.org/pypy/pypy3.11-v7.3.19-win64.zip'; \
 	\
 	Write-Host 'Verifying install ("pypy --version") ...'; \
 	pypy --version; \
+# double quotes in Docker WCOW + PowerShell is something that's totally and completely unsupported thanks to cmd.exe: https://github.com/docker-library/pypy/pull/88#issuecomment-2699167808
+	$pypyPython = pypy -c 'import sys; print(''.''.join(map(str, sys.version_info[0:3])))'; \
+	if ($pypyPython -ne '3.11.11') { \
+		Write-Host ('Python version mismatch: {0} vs {1}' -f $pypyPython, '3.11.11'); \
+		exit 1; \
+	}; \
 	\
 	Write-Host 'Cleanup install ...'; \
 	Get-ChildItem \

--- a/3.11/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/3.11/windows/windowsservercore-ltsc2022/Dockerfile
@@ -69,6 +69,12 @@ RUN $url = 'https://downloads.python.org/pypy/pypy3.11-v7.3.19-win64.zip'; \
 	\
 	Write-Host 'Verifying install ("pypy --version") ...'; \
 	pypy --version; \
+# double quotes in Docker WCOW + PowerShell is something that's totally and completely unsupported thanks to cmd.exe: https://github.com/docker-library/pypy/pull/88#issuecomment-2699167808
+	$pypyPython = pypy -c 'import sys; print(''.''.join(map(str, sys.version_info[0:3])))'; \
+	if ($pypyPython -ne '3.11.11') { \
+		Write-Host ('Python version mismatch: {0} vs {1}' -f $pypyPython, '3.11.11'); \
+		exit 1; \
+	}; \
 	\
 	Write-Host 'Cleanup install ...'; \
 	Get-ChildItem \

--- a/3.11/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/3.11/windows/windowsservercore-ltsc2025/Dockerfile
@@ -69,6 +69,12 @@ RUN $url = 'https://downloads.python.org/pypy/pypy3.11-v7.3.19-win64.zip'; \
 	\
 	Write-Host 'Verifying install ("pypy --version") ...'; \
 	pypy --version; \
+# double quotes in Docker WCOW + PowerShell is something that's totally and completely unsupported thanks to cmd.exe: https://github.com/docker-library/pypy/pull/88#issuecomment-2699167808
+	$pypyPython = pypy -c 'import sys; print(''.''.join(map(str, sys.version_info[0:3])))'; \
+	if ($pypyPython -ne '3.11.11') { \
+		Write-Host ('Python version mismatch: {0} vs {1}' -f $pypyPython, '3.11.11'); \
+		exit 1; \
+	}; \
 	\
 	Write-Host 'Cleanup install ...'; \
 	Get-ChildItem \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -115,6 +115,9 @@ RUN set -eux; \
 	\
 # smoke test
 	{{ cmd }} --version; \
+# verify (C)Python version is accurate
+	pypyPython="$({{ cmd }} -c 'import sys; print(".".join(map(str, sys.version_info[0:3])))')"; \
+	[ "$pypyPython" = {{ .python.version | @sh }} ]; \
 	\
 {{ if is_3 then ( -}}
 	cd {{ lib_pypy }}; \

--- a/Dockerfile-windows-servercore.template
+++ b/Dockerfile-windows-servercore.template
@@ -69,6 +69,12 @@ RUN $url = '{{ .arches["windows-amd64"].url }}'; \
 	\
 	Write-Host 'Verifying install ("pypy --version") ...'; \
 	pypy --version; \
+# double quotes in Docker WCOW + PowerShell is something that's totally and completely unsupported thanks to cmd.exe: https://github.com/docker-library/pypy/pull/88#issuecomment-2699167808
+	$pypyPython = pypy -c 'import sys; print(''.''.join(map(str, sys.version_info[0:3])))'; \
+	if ($pypyPython -ne {{ .python.version | @sh }}) { \
+		Write-Host ('Python version mismatch: {0} vs {1}' -f $pypyPython, {{ .python.version | @sh }}); \
+		exit 1; \
+	}; \
 	\
 	Write-Host 'Cleanup install ...'; \
 	Get-ChildItem \


### PR DESCRIPTION
This asks PyPy to tell us which version of Python it is so we can validate that we're claiming the correct one.

This is related to https://github.com/docker-library/pypy/commit/94d8ce9e0dc242cd5ca085c34b92fc7ed4c43182, but the impact is 100% superficial (and only exhibits in a comment in our `Dockerfile`s, in fact), so I'm not actually convinced this makes any sense to go forward with, but figured I'd open it for discussion (since it's really trivial for us to verify).