### PR TITLE
Swap from explicit `get-pip.py` to `ensurepip`

### DIFF
--- a/2.7/bookworm/Dockerfile
+++ b/2.7/bookworm/Dockerfile
@@ -82,32 +82,7 @@ RUN set -eux; \
 # smoke test again, to be sure
 	pypy --version; \
 	\
-	find /opt/pypy -depth \
-		\( \
-			\( -type d -a \( -name test -o -name tests \) \) \
-			-o \
-			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' +
-
-# https://github.com/pypa/get-pip
-ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py
-ENV PYTHON_GET_PIP_SHA256 95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218
-
-RUN set -ex; \
-	\
-	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
-	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
-	\
-	pipVersion="$(pypy -c 'import ensurepip; print(ensurepip._PIP_VERSION)')"; \
-	setuptoolsVersion="$(pypy -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)')"; \
-	\
-	pypy get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		"pip == $pipVersion" \
-		"setuptools == $setuptoolsVersion" \
-	; \
-# smoke test
+	pypy -m ensurepip --default-pip; \
 	pip --version; \
 	\
 	find /opt/pypy -depth \
@@ -115,7 +90,6 @@ RUN set -ex; \
 			\( -type d -a \( -name test -o -name tests \) \) \
 			-o \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' +; \
-	rm -f get-pip.py
+		\) -exec rm -rf '{}' +
 
 CMD ["pypy"]

--- a/2.7/bookworm/Dockerfile
+++ b/2.7/bookworm/Dockerfile
@@ -84,6 +84,9 @@ RUN set -eux; \
 	\
 	pypy -m ensurepip --default-pip; \
 	pip --version; \
+# https://github.com/docker-library/python/issues/952
+# https://github.com/docker-library/python/issues/1023
+	pip install --disable-pip-version-check --no-cache-dir --no-compile 'wheel<0.46'; \
 	\
 	find /opt/pypy -depth \
 		\( \

--- a/2.7/bullseye/Dockerfile
+++ b/2.7/bullseye/Dockerfile
@@ -82,32 +82,7 @@ RUN set -eux; \
 # smoke test again, to be sure
 	pypy --version; \
 	\
-	find /opt/pypy -depth \
-		\( \
-			\( -type d -a \( -name test -o -name tests \) \) \
-			-o \
-			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' +
-
-# https://github.com/pypa/get-pip
-ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py
-ENV PYTHON_GET_PIP_SHA256 95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218
-
-RUN set -ex; \
-	\
-	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
-	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
-	\
-	pipVersion="$(pypy -c 'import ensurepip; print(ensurepip._PIP_VERSION)')"; \
-	setuptoolsVersion="$(pypy -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)')"; \
-	\
-	pypy get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		"pip == $pipVersion" \
-		"setuptools == $setuptoolsVersion" \
-	; \
-# smoke test
+	pypy -m ensurepip --default-pip; \
 	pip --version; \
 	\
 	find /opt/pypy -depth \
@@ -115,7 +90,6 @@ RUN set -ex; \
 			\( -type d -a \( -name test -o -name tests \) \) \
 			-o \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' +; \
-	rm -f get-pip.py
+		\) -exec rm -rf '{}' +
 
 CMD ["pypy"]

--- a/2.7/bullseye/Dockerfile
+++ b/2.7/bullseye/Dockerfile
@@ -84,6 +84,9 @@ RUN set -eux; \
 	\
 	pypy -m ensurepip --default-pip; \
 	pip --version; \
+# https://github.com/docker-library/python/issues/952
+# https://github.com/docker-library/python/issues/1023
+	pip install --disable-pip-version-check --no-cache-dir --no-compile 'wheel<0.46'; \
 	\
 	find /opt/pypy -depth \
 		\( \

--- a/2.7/slim-bookworm/Dockerfile
+++ b/2.7/slim-bookworm/Dockerfile
@@ -80,36 +80,7 @@ RUN set -eux; \
 # smoke test again, to be sure
 	pypy --version; \
 	\
-	find /opt/pypy -depth \
-		\( \
-			\( -type d -a \( -name test -o -name tests \) \) \
-			-o \
-			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' +
-
-# https://github.com/pypa/get-pip
-ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py
-ENV PYTHON_GET_PIP_SHA256 95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218
-
-RUN set -ex; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends wget; \
-	rm -rf /var/lib/apt/lists/*; \
-	\
-	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
-	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
-	\
-	pipVersion="$(pypy -c 'import ensurepip; print(ensurepip._PIP_VERSION)')"; \
-	setuptoolsVersion="$(pypy -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)')"; \
-	\
-	pypy get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		"pip == $pipVersion" \
-		"setuptools == $setuptoolsVersion" \
-	; \
-	apt-get purge -y --auto-remove wget; \
-# smoke test
+	pypy -m ensurepip --default-pip; \
 	pip --version; \
 	\
 	find /opt/pypy -depth \
@@ -117,7 +88,6 @@ RUN set -ex; \
 			\( -type d -a \( -name test -o -name tests \) \) \
 			-o \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' +; \
-	rm -f get-pip.py
+		\) -exec rm -rf '{}' +
 
 CMD ["pypy"]

--- a/2.7/slim-bookworm/Dockerfile
+++ b/2.7/slim-bookworm/Dockerfile
@@ -82,6 +82,9 @@ RUN set -eux; \
 	\
 	pypy -m ensurepip --default-pip; \
 	pip --version; \
+# https://github.com/docker-library/python/issues/952
+# https://github.com/docker-library/python/issues/1023
+	pip install --disable-pip-version-check --no-cache-dir --no-compile 'wheel<0.46'; \
 	\
 	find /opt/pypy -depth \
 		\( \

--- a/2.7/slim-bullseye/Dockerfile
+++ b/2.7/slim-bullseye/Dockerfile
@@ -80,36 +80,7 @@ RUN set -eux; \
 # smoke test again, to be sure
 	pypy --version; \
 	\
-	find /opt/pypy -depth \
-		\( \
-			\( -type d -a \( -name test -o -name tests \) \) \
-			-o \
-			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' +
-
-# https://github.com/pypa/get-pip
-ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py
-ENV PYTHON_GET_PIP_SHA256 95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218
-
-RUN set -ex; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends wget; \
-	rm -rf /var/lib/apt/lists/*; \
-	\
-	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
-	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
-	\
-	pipVersion="$(pypy -c 'import ensurepip; print(ensurepip._PIP_VERSION)')"; \
-	setuptoolsVersion="$(pypy -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)')"; \
-	\
-	pypy get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		"pip == $pipVersion" \
-		"setuptools == $setuptoolsVersion" \
-	; \
-	apt-get purge -y --auto-remove wget; \
-# smoke test
+	pypy -m ensurepip --default-pip; \
 	pip --version; \
 	\
 	find /opt/pypy -depth \
@@ -117,7 +88,6 @@ RUN set -ex; \
 			\( -type d -a \( -name test -o -name tests \) \) \
 			-o \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' +; \
-	rm -f get-pip.py
+		\) -exec rm -rf '{}' +
 
 CMD ["pypy"]

--- a/2.7/slim-bullseye/Dockerfile
+++ b/2.7/slim-bullseye/Dockerfile
@@ -82,6 +82,9 @@ RUN set -eux; \
 	\
 	pypy -m ensurepip --default-pip; \
 	pip --version; \
+# https://github.com/docker-library/python/issues/952
+# https://github.com/docker-library/python/issues/1023
+	pip install --disable-pip-version-check --no-cache-dir --no-compile 'wheel<0.46'; \
 	\
 	find /opt/pypy -depth \
 		\( \

--- a/2.7/windows/windowsservercore-1809/Dockerfile
+++ b/2.7/windows/windowsservercore-1809/Dockerfile
@@ -73,46 +73,8 @@ RUN $url = 'https://downloads.python.org/pypy/pypy2.7-v7.3.19-win64.zip'; \
 	Write-Host 'Verifying install ("pypy --version") ...'; \
 	pypy --version; \
 	\
-	Write-Host 'Cleanup install ...'; \
-	Get-ChildItem \
-		-Path C:\pypy \
-		-Include @( 'test', 'tests' ) \
-		-Directory \
-		-Recurse \
-		| Remove-Item -Force -Recurse; \
-	Get-ChildItem \
-		-Path C:\pypy \
-		-Include @( '*.pyc', '*.pyo' ) \
-		-File \
-		-Recurse \
-		| Remove-Item -Force; \
-	\
-	Write-Host 'Complete.'
-
-# https://github.com/pypa/get-pip
-ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py
-ENV PYTHON_GET_PIP_SHA256 95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218
-
-RUN Write-Host ('Downloading get-pip.py ({0}) ...' -f $env:PYTHON_GET_PIP_URL); \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -Uri $env:PYTHON_GET_PIP_URL -OutFile 'get-pip.py'; \
-	Write-Host ('Verifying sha256 ({0}) ...' -f $env:PYTHON_GET_PIP_SHA256); \
-	if ((Get-FileHash 'get-pip.py' -Algorithm sha256).Hash -ne $env:PYTHON_GET_PIP_SHA256) { \
-		Write-Host 'FAILED!'; \
-		exit 1; \
-	}; \
-	\
-	$pipVersion = & pypy -c 'import ensurepip; print(ensurepip._PIP_VERSION)'; \
-	$setuptoolsVersion = & pypy -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)'; \
-	\
-	Write-Host ('Installing "pip == {0}", "setuptools == {1}" ...' -f $pipVersion, $setuptoolsVersion); \
-	pypy get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		('pip == {0}' -f $pipVersion) \
-		('setuptools == {0}' -f $setuptoolsVersion) \
-	; \
-	Remove-Item get-pip.py -Force; \
+	Write-Host 'Installing pip ...'; \
+	pypy -m ensurepip --default-pip; \
 	\
 	Write-Host 'Verifying pip install ...'; \
 	pip --version; \

--- a/2.7/windows/windowsservercore-1809/Dockerfile
+++ b/2.7/windows/windowsservercore-1809/Dockerfile
@@ -79,6 +79,11 @@ RUN $url = 'https://downloads.python.org/pypy/pypy2.7-v7.3.19-win64.zip'; \
 	Write-Host 'Verifying pip install ...'; \
 	pip --version; \
 	\
+	Write-Host 'Installing "wheel" (backwards compat) ...'; \
+# https://github.com/docker-library/python/issues/952
+# https://github.com/docker-library/python/issues/1023
+	pip install --disable-pip-version-check --no-cache-dir --no-compile 'wheel<0.46'; \
+	\
 	Write-Host 'Cleanup install ...'; \
 	Get-ChildItem \
 		-Path C:\pypy \

--- a/2.7/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/2.7/windows/windowsservercore-ltsc2022/Dockerfile
@@ -73,46 +73,8 @@ RUN $url = 'https://downloads.python.org/pypy/pypy2.7-v7.3.19-win64.zip'; \
 	Write-Host 'Verifying install ("pypy --version") ...'; \
 	pypy --version; \
 	\
-	Write-Host 'Cleanup install ...'; \
-	Get-ChildItem \
-		-Path C:\pypy \
-		-Include @( 'test', 'tests' ) \
-		-Directory \
-		-Recurse \
-		| Remove-Item -Force -Recurse; \
-	Get-ChildItem \
-		-Path C:\pypy \
-		-Include @( '*.pyc', '*.pyo' ) \
-		-File \
-		-Recurse \
-		| Remove-Item -Force; \
-	\
-	Write-Host 'Complete.'
-
-# https://github.com/pypa/get-pip
-ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py
-ENV PYTHON_GET_PIP_SHA256 95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218
-
-RUN Write-Host ('Downloading get-pip.py ({0}) ...' -f $env:PYTHON_GET_PIP_URL); \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -Uri $env:PYTHON_GET_PIP_URL -OutFile 'get-pip.py'; \
-	Write-Host ('Verifying sha256 ({0}) ...' -f $env:PYTHON_GET_PIP_SHA256); \
-	if ((Get-FileHash 'get-pip.py' -Algorithm sha256).Hash -ne $env:PYTHON_GET_PIP_SHA256) { \
-		Write-Host 'FAILED!'; \
-		exit 1; \
-	}; \
-	\
-	$pipVersion = & pypy -c 'import ensurepip; print(ensurepip._PIP_VERSION)'; \
-	$setuptoolsVersion = & pypy -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)'; \
-	\
-	Write-Host ('Installing "pip == {0}", "setuptools == {1}" ...' -f $pipVersion, $setuptoolsVersion); \
-	pypy get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		('pip == {0}' -f $pipVersion) \
-		('setuptools == {0}' -f $setuptoolsVersion) \
-	; \
-	Remove-Item get-pip.py -Force; \
+	Write-Host 'Installing pip ...'; \
+	pypy -m ensurepip --default-pip; \
 	\
 	Write-Host 'Verifying pip install ...'; \
 	pip --version; \

--- a/2.7/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/2.7/windows/windowsservercore-ltsc2022/Dockerfile
@@ -79,6 +79,11 @@ RUN $url = 'https://downloads.python.org/pypy/pypy2.7-v7.3.19-win64.zip'; \
 	Write-Host 'Verifying pip install ...'; \
 	pip --version; \
 	\
+	Write-Host 'Installing "wheel" (backwards compat) ...'; \
+# https://github.com/docker-library/python/issues/952
+# https://github.com/docker-library/python/issues/1023
+	pip install --disable-pip-version-check --no-cache-dir --no-compile 'wheel<0.46'; \
+	\
 	Write-Host 'Cleanup install ...'; \
 	Get-ChildItem \
 		-Path C:\pypy \

--- a/2.7/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/2.7/windows/windowsservercore-ltsc2025/Dockerfile
@@ -73,46 +73,8 @@ RUN $url = 'https://downloads.python.org/pypy/pypy2.7-v7.3.19-win64.zip'; \
 	Write-Host 'Verifying install ("pypy --version") ...'; \
 	pypy --version; \
 	\
-	Write-Host 'Cleanup install ...'; \
-	Get-ChildItem \
-		-Path C:\pypy \
-		-Include @( 'test', 'tests' ) \
-		-Directory \
-		-Recurse \
-		| Remove-Item -Force -Recurse; \
-	Get-ChildItem \
-		-Path C:\pypy \
-		-Include @( '*.pyc', '*.pyo' ) \
-		-File \
-		-Recurse \
-		| Remove-Item -Force; \
-	\
-	Write-Host 'Complete.'
-
-# https://github.com/pypa/get-pip
-ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py
-ENV PYTHON_GET_PIP_SHA256 95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218
-
-RUN Write-Host ('Downloading get-pip.py ({0}) ...' -f $env:PYTHON_GET_PIP_URL); \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -Uri $env:PYTHON_GET_PIP_URL -OutFile 'get-pip.py'; \
-	Write-Host ('Verifying sha256 ({0}) ...' -f $env:PYTHON_GET_PIP_SHA256); \
-	if ((Get-FileHash 'get-pip.py' -Algorithm sha256).Hash -ne $env:PYTHON_GET_PIP_SHA256) { \
-		Write-Host 'FAILED!'; \
-		exit 1; \
-	}; \
-	\
-	$pipVersion = & pypy -c 'import ensurepip; print(ensurepip._PIP_VERSION)'; \
-	$setuptoolsVersion = & pypy -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)'; \
-	\
-	Write-Host ('Installing "pip == {0}", "setuptools == {1}" ...' -f $pipVersion, $setuptoolsVersion); \
-	pypy get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		('pip == {0}' -f $pipVersion) \
-		('setuptools == {0}' -f $setuptoolsVersion) \
-	; \
-	Remove-Item get-pip.py -Force; \
+	Write-Host 'Installing pip ...'; \
+	pypy -m ensurepip --default-pip; \
 	\
 	Write-Host 'Verifying pip install ...'; \
 	pip --version; \

--- a/2.7/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/2.7/windows/windowsservercore-ltsc2025/Dockerfile
@@ -79,6 +79,11 @@ RUN $url = 'https://downloads.python.org/pypy/pypy2.7-v7.3.19-win64.zip'; \
 	Write-Host 'Verifying pip install ...'; \
 	pip --version; \
 	\
+	Write-Host 'Installing "wheel" (backwards compat) ...'; \
+# https://github.com/docker-library/python/issues/952
+# https://github.com/docker-library/python/issues/1023
+	pip install --disable-pip-version-check --no-cache-dir --no-compile 'wheel<0.46'; \
+	\
 	Write-Host 'Cleanup install ...'; \
 	Get-ChildItem \
 		-Path C:\pypy \

--- a/3.10/bookworm/Dockerfile
+++ b/3.10/bookworm/Dockerfile
@@ -101,32 +101,7 @@ RUN set -eux; \
 # smoke test again, to be sure
 	pypy3 --version; \
 	\
-	find /opt/pypy -depth \
-		\( \
-			\( -type d -a \( -name test -o -name tests \) \) \
-			-o \
-			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' +
-
-# https://github.com/pypa/get-pip
-ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py
-ENV PYTHON_GET_PIP_SHA256 95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218
-
-RUN set -ex; \
-	\
-	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
-	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
-	\
-	pipVersion="$(pypy3 -c 'import ensurepip; print(ensurepip._PIP_VERSION)')"; \
-	setuptoolsVersion="$(pypy3 -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)')"; \
-	\
-	pypy3 get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		"pip == $pipVersion" \
-		"setuptools == $setuptoolsVersion" \
-	; \
-# smoke test
+	pypy3 -m ensurepip --default-pip; \
 	pip --version; \
 	\
 	find /opt/pypy -depth \
@@ -134,7 +109,6 @@ RUN set -ex; \
 			\( -type d -a \( -name test -o -name tests \) \) \
 			-o \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' +; \
-	rm -f get-pip.py
+		\) -exec rm -rf '{}' +
 
 CMD ["pypy3"]

--- a/3.10/bookworm/Dockerfile
+++ b/3.10/bookworm/Dockerfile
@@ -103,6 +103,9 @@ RUN set -eux; \
 	\
 	pypy3 -m ensurepip --default-pip; \
 	pip --version; \
+# https://github.com/docker-library/python/issues/952
+# https://github.com/docker-library/python/issues/1023
+	pip install --disable-pip-version-check --no-cache-dir --no-compile 'wheel<0.46'; \
 	\
 	find /opt/pypy -depth \
 		\( \

--- a/3.10/bullseye/Dockerfile
+++ b/3.10/bullseye/Dockerfile
@@ -101,32 +101,7 @@ RUN set -eux; \
 # smoke test again, to be sure
 	pypy3 --version; \
 	\
-	find /opt/pypy -depth \
-		\( \
-			\( -type d -a \( -name test -o -name tests \) \) \
-			-o \
-			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' +
-
-# https://github.com/pypa/get-pip
-ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py
-ENV PYTHON_GET_PIP_SHA256 95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218
-
-RUN set -ex; \
-	\
-	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
-	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
-	\
-	pipVersion="$(pypy3 -c 'import ensurepip; print(ensurepip._PIP_VERSION)')"; \
-	setuptoolsVersion="$(pypy3 -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)')"; \
-	\
-	pypy3 get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		"pip == $pipVersion" \
-		"setuptools == $setuptoolsVersion" \
-	; \
-# smoke test
+	pypy3 -m ensurepip --default-pip; \
 	pip --version; \
 	\
 	find /opt/pypy -depth \
@@ -134,7 +109,6 @@ RUN set -ex; \
 			\( -type d -a \( -name test -o -name tests \) \) \
 			-o \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' +; \
-	rm -f get-pip.py
+		\) -exec rm -rf '{}' +
 
 CMD ["pypy3"]

--- a/3.10/bullseye/Dockerfile
+++ b/3.10/bullseye/Dockerfile
@@ -103,6 +103,9 @@ RUN set -eux; \
 	\
 	pypy3 -m ensurepip --default-pip; \
 	pip --version; \
+# https://github.com/docker-library/python/issues/952
+# https://github.com/docker-library/python/issues/1023
+	pip install --disable-pip-version-check --no-cache-dir --no-compile 'wheel<0.46'; \
 	\
 	find /opt/pypy -depth \
 		\( \

--- a/3.10/slim-bookworm/Dockerfile
+++ b/3.10/slim-bookworm/Dockerfile
@@ -103,36 +103,7 @@ RUN set -eux; \
 # smoke test again, to be sure
 	pypy3 --version; \
 	\
-	find /opt/pypy -depth \
-		\( \
-			\( -type d -a \( -name test -o -name tests \) \) \
-			-o \
-			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' +
-
-# https://github.com/pypa/get-pip
-ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py
-ENV PYTHON_GET_PIP_SHA256 95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218
-
-RUN set -ex; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends wget; \
-	rm -rf /var/lib/apt/lists/*; \
-	\
-	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
-	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
-	\
-	pipVersion="$(pypy3 -c 'import ensurepip; print(ensurepip._PIP_VERSION)')"; \
-	setuptoolsVersion="$(pypy3 -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)')"; \
-	\
-	pypy3 get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		"pip == $pipVersion" \
-		"setuptools == $setuptoolsVersion" \
-	; \
-	apt-get purge -y --auto-remove wget; \
-# smoke test
+	pypy3 -m ensurepip --default-pip; \
 	pip --version; \
 	\
 	find /opt/pypy -depth \
@@ -140,7 +111,6 @@ RUN set -ex; \
 			\( -type d -a \( -name test -o -name tests \) \) \
 			-o \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' +; \
-	rm -f get-pip.py
+		\) -exec rm -rf '{}' +
 
 CMD ["pypy3"]

--- a/3.10/slim-bookworm/Dockerfile
+++ b/3.10/slim-bookworm/Dockerfile
@@ -105,6 +105,9 @@ RUN set -eux; \
 	\
 	pypy3 -m ensurepip --default-pip; \
 	pip --version; \
+# https://github.com/docker-library/python/issues/952
+# https://github.com/docker-library/python/issues/1023
+	pip install --disable-pip-version-check --no-cache-dir --no-compile 'wheel<0.46'; \
 	\
 	find /opt/pypy -depth \
 		\( \

--- a/3.10/slim-bullseye/Dockerfile
+++ b/3.10/slim-bullseye/Dockerfile
@@ -103,36 +103,7 @@ RUN set -eux; \
 # smoke test again, to be sure
 	pypy3 --version; \
 	\
-	find /opt/pypy -depth \
-		\( \
-			\( -type d -a \( -name test -o -name tests \) \) \
-			-o \
-			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' +
-
-# https://github.com/pypa/get-pip
-ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py
-ENV PYTHON_GET_PIP_SHA256 95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218
-
-RUN set -ex; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends wget; \
-	rm -rf /var/lib/apt/lists/*; \
-	\
-	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
-	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
-	\
-	pipVersion="$(pypy3 -c 'import ensurepip; print(ensurepip._PIP_VERSION)')"; \
-	setuptoolsVersion="$(pypy3 -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)')"; \
-	\
-	pypy3 get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		"pip == $pipVersion" \
-		"setuptools == $setuptoolsVersion" \
-	; \
-	apt-get purge -y --auto-remove wget; \
-# smoke test
+	pypy3 -m ensurepip --default-pip; \
 	pip --version; \
 	\
 	find /opt/pypy -depth \
@@ -140,7 +111,6 @@ RUN set -ex; \
 			\( -type d -a \( -name test -o -name tests \) \) \
 			-o \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' +; \
-	rm -f get-pip.py
+		\) -exec rm -rf '{}' +
 
 CMD ["pypy3"]

--- a/3.10/slim-bullseye/Dockerfile
+++ b/3.10/slim-bullseye/Dockerfile
@@ -105,6 +105,9 @@ RUN set -eux; \
 	\
 	pypy3 -m ensurepip --default-pip; \
 	pip --version; \
+# https://github.com/docker-library/python/issues/952
+# https://github.com/docker-library/python/issues/1023
+	pip install --disable-pip-version-check --no-cache-dir --no-compile 'wheel<0.46'; \
 	\
 	find /opt/pypy -depth \
 		\( \

--- a/3.10/windows/windowsservercore-1809/Dockerfile
+++ b/3.10/windows/windowsservercore-1809/Dockerfile
@@ -70,46 +70,8 @@ RUN $url = 'https://downloads.python.org/pypy/pypy3.10-v7.3.19-win64.zip'; \
 	Write-Host 'Verifying install ("pypy --version") ...'; \
 	pypy --version; \
 	\
-	Write-Host 'Cleanup install ...'; \
-	Get-ChildItem \
-		-Path C:\pypy \
-		-Include @( 'test', 'tests' ) \
-		-Directory \
-		-Recurse \
-		| Remove-Item -Force -Recurse; \
-	Get-ChildItem \
-		-Path C:\pypy \
-		-Include @( '*.pyc', '*.pyo' ) \
-		-File \
-		-Recurse \
-		| Remove-Item -Force; \
-	\
-	Write-Host 'Complete.'
-
-# https://github.com/pypa/get-pip
-ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py
-ENV PYTHON_GET_PIP_SHA256 95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218
-
-RUN Write-Host ('Downloading get-pip.py ({0}) ...' -f $env:PYTHON_GET_PIP_URL); \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -Uri $env:PYTHON_GET_PIP_URL -OutFile 'get-pip.py'; \
-	Write-Host ('Verifying sha256 ({0}) ...' -f $env:PYTHON_GET_PIP_SHA256); \
-	if ((Get-FileHash 'get-pip.py' -Algorithm sha256).Hash -ne $env:PYTHON_GET_PIP_SHA256) { \
-		Write-Host 'FAILED!'; \
-		exit 1; \
-	}; \
-	\
-	$pipVersion = & pypy -c 'import ensurepip; print(ensurepip._PIP_VERSION)'; \
-	$setuptoolsVersion = & pypy -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)'; \
-	\
-	Write-Host ('Installing "pip == {0}", "setuptools == {1}" ...' -f $pipVersion, $setuptoolsVersion); \
-	pypy get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		('pip == {0}' -f $pipVersion) \
-		('setuptools == {0}' -f $setuptoolsVersion) \
-	; \
-	Remove-Item get-pip.py -Force; \
+	Write-Host 'Installing pip ...'; \
+	pypy -m ensurepip --default-pip; \
 	\
 	Write-Host 'Verifying pip install ...'; \
 	pip --version; \

--- a/3.10/windows/windowsservercore-1809/Dockerfile
+++ b/3.10/windows/windowsservercore-1809/Dockerfile
@@ -76,6 +76,11 @@ RUN $url = 'https://downloads.python.org/pypy/pypy3.10-v7.3.19-win64.zip'; \
 	Write-Host 'Verifying pip install ...'; \
 	pip --version; \
 	\
+	Write-Host 'Installing "wheel" (backwards compat) ...'; \
+# https://github.com/docker-library/python/issues/952
+# https://github.com/docker-library/python/issues/1023
+	pip install --disable-pip-version-check --no-cache-dir --no-compile 'wheel<0.46'; \
+	\
 	Write-Host 'Cleanup install ...'; \
 	Get-ChildItem \
 		-Path C:\pypy \

--- a/3.10/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/3.10/windows/windowsservercore-ltsc2022/Dockerfile
@@ -70,46 +70,8 @@ RUN $url = 'https://downloads.python.org/pypy/pypy3.10-v7.3.19-win64.zip'; \
 	Write-Host 'Verifying install ("pypy --version") ...'; \
 	pypy --version; \
 	\
-	Write-Host 'Cleanup install ...'; \
-	Get-ChildItem \
-		-Path C:\pypy \
-		-Include @( 'test', 'tests' ) \
-		-Directory \
-		-Recurse \
-		| Remove-Item -Force -Recurse; \
-	Get-ChildItem \
-		-Path C:\pypy \
-		-Include @( '*.pyc', '*.pyo' ) \
-		-File \
-		-Recurse \
-		| Remove-Item -Force; \
-	\
-	Write-Host 'Complete.'
-
-# https://github.com/pypa/get-pip
-ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py
-ENV PYTHON_GET_PIP_SHA256 95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218
-
-RUN Write-Host ('Downloading get-pip.py ({0}) ...' -f $env:PYTHON_GET_PIP_URL); \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -Uri $env:PYTHON_GET_PIP_URL -OutFile 'get-pip.py'; \
-	Write-Host ('Verifying sha256 ({0}) ...' -f $env:PYTHON_GET_PIP_SHA256); \
-	if ((Get-FileHash 'get-pip.py' -Algorithm sha256).Hash -ne $env:PYTHON_GET_PIP_SHA256) { \
-		Write-Host 'FAILED!'; \
-		exit 1; \
-	}; \
-	\
-	$pipVersion = & pypy -c 'import ensurepip; print(ensurepip._PIP_VERSION)'; \
-	$setuptoolsVersion = & pypy -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)'; \
-	\
-	Write-Host ('Installing "pip == {0}", "setuptools == {1}" ...' -f $pipVersion, $setuptoolsVersion); \
-	pypy get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		('pip == {0}' -f $pipVersion) \
-		('setuptools == {0}' -f $setuptoolsVersion) \
-	; \
-	Remove-Item get-pip.py -Force; \
+	Write-Host 'Installing pip ...'; \
+	pypy -m ensurepip --default-pip; \
 	\
 	Write-Host 'Verifying pip install ...'; \
 	pip --version; \

--- a/3.10/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/3.10/windows/windowsservercore-ltsc2022/Dockerfile
@@ -76,6 +76,11 @@ RUN $url = 'https://downloads.python.org/pypy/pypy3.10-v7.3.19-win64.zip'; \
 	Write-Host 'Verifying pip install ...'; \
 	pip --version; \
 	\
+	Write-Host 'Installing "wheel" (backwards compat) ...'; \
+# https://github.com/docker-library/python/issues/952
+# https://github.com/docker-library/python/issues/1023
+	pip install --disable-pip-version-check --no-cache-dir --no-compile 'wheel<0.46'; \
+	\
 	Write-Host 'Cleanup install ...'; \
 	Get-ChildItem \
 		-Path C:\pypy \

--- a/3.10/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/3.10/windows/windowsservercore-ltsc2025/Dockerfile
@@ -70,46 +70,8 @@ RUN $url = 'https://downloads.python.org/pypy/pypy3.10-v7.3.19-win64.zip'; \
 	Write-Host 'Verifying install ("pypy --version") ...'; \
 	pypy --version; \
 	\
-	Write-Host 'Cleanup install ...'; \
-	Get-ChildItem \
-		-Path C:\pypy \
-		-Include @( 'test', 'tests' ) \
-		-Directory \
-		-Recurse \
-		| Remove-Item -Force -Recurse; \
-	Get-ChildItem \
-		-Path C:\pypy \
-		-Include @( '*.pyc', '*.pyo' ) \
-		-File \
-		-Recurse \
-		| Remove-Item -Force; \
-	\
-	Write-Host 'Complete.'
-
-# https://github.com/pypa/get-pip
-ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py
-ENV PYTHON_GET_PIP_SHA256 95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218
-
-RUN Write-Host ('Downloading get-pip.py ({0}) ...' -f $env:PYTHON_GET_PIP_URL); \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -Uri $env:PYTHON_GET_PIP_URL -OutFile 'get-pip.py'; \
-	Write-Host ('Verifying sha256 ({0}) ...' -f $env:PYTHON_GET_PIP_SHA256); \
-	if ((Get-FileHash 'get-pip.py' -Algorithm sha256).Hash -ne $env:PYTHON_GET_PIP_SHA256) { \
-		Write-Host 'FAILED!'; \
-		exit 1; \
-	}; \
-	\
-	$pipVersion = & pypy -c 'import ensurepip; print(ensurepip._PIP_VERSION)'; \
-	$setuptoolsVersion = & pypy -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)'; \
-	\
-	Write-Host ('Installing "pip == {0}", "setuptools == {1}" ...' -f $pipVersion, $setuptoolsVersion); \
-	pypy get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		('pip == {0}' -f $pipVersion) \
-		('setuptools == {0}' -f $setuptoolsVersion) \
-	; \
-	Remove-Item get-pip.py -Force; \
+	Write-Host 'Installing pip ...'; \
+	pypy -m ensurepip --default-pip; \
 	\
 	Write-Host 'Verifying pip install ...'; \
 	pip --version; \

--- a/3.10/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/3.10/windows/windowsservercore-ltsc2025/Dockerfile
@@ -76,6 +76,11 @@ RUN $url = 'https://downloads.python.org/pypy/pypy3.10-v7.3.19-win64.zip'; \
 	Write-Host 'Verifying pip install ...'; \
 	pip --version; \
 	\
+	Write-Host 'Installing "wheel" (backwards compat) ...'; \
+# https://github.com/docker-library/python/issues/952
+# https://github.com/docker-library/python/issues/1023
+	pip install --disable-pip-version-check --no-cache-dir --no-compile 'wheel<0.46'; \
+	\
 	Write-Host 'Cleanup install ...'; \
 	Get-ChildItem \
 		-Path C:\pypy \

--- a/3.11/bookworm/Dockerfile
+++ b/3.11/bookworm/Dockerfile
@@ -101,32 +101,7 @@ RUN set -eux; \
 # smoke test again, to be sure
 	pypy3 --version; \
 	\
-	find /opt/pypy -depth \
-		\( \
-			\( -type d -a \( -name test -o -name tests \) \) \
-			-o \
-			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' +
-
-# https://github.com/pypa/get-pip
-ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py
-ENV PYTHON_GET_PIP_SHA256 95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218
-
-RUN set -ex; \
-	\
-	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
-	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
-	\
-	pipVersion="$(pypy3 -c 'import ensurepip; print(ensurepip._PIP_VERSION)')"; \
-	setuptoolsVersion="$(pypy3 -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)')"; \
-	\
-	pypy3 get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		"pip == $pipVersion" \
-		"setuptools == $setuptoolsVersion" \
-	; \
-# smoke test
+	pypy3 -m ensurepip --default-pip; \
 	pip --version; \
 	\
 	find /opt/pypy -depth \
@@ -134,7 +109,6 @@ RUN set -ex; \
 			\( -type d -a \( -name test -o -name tests \) \) \
 			-o \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' +; \
-	rm -f get-pip.py
+		\) -exec rm -rf '{}' +
 
 CMD ["pypy3"]

--- a/3.11/bookworm/Dockerfile
+++ b/3.11/bookworm/Dockerfile
@@ -103,6 +103,9 @@ RUN set -eux; \
 	\
 	pypy3 -m ensurepip --default-pip; \
 	pip --version; \
+# https://github.com/docker-library/python/issues/952
+# https://github.com/docker-library/python/issues/1023
+	pip install --disable-pip-version-check --no-cache-dir --no-compile 'wheel<0.46'; \
 	\
 	find /opt/pypy -depth \
 		\( \

--- a/3.11/slim-bookworm/Dockerfile
+++ b/3.11/slim-bookworm/Dockerfile
@@ -103,36 +103,7 @@ RUN set -eux; \
 # smoke test again, to be sure
 	pypy3 --version; \
 	\
-	find /opt/pypy -depth \
-		\( \
-			\( -type d -a \( -name test -o -name tests \) \) \
-			-o \
-			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' +
-
-# https://github.com/pypa/get-pip
-ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py
-ENV PYTHON_GET_PIP_SHA256 95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218
-
-RUN set -ex; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends wget; \
-	rm -rf /var/lib/apt/lists/*; \
-	\
-	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
-	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
-	\
-	pipVersion="$(pypy3 -c 'import ensurepip; print(ensurepip._PIP_VERSION)')"; \
-	setuptoolsVersion="$(pypy3 -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)')"; \
-	\
-	pypy3 get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		"pip == $pipVersion" \
-		"setuptools == $setuptoolsVersion" \
-	; \
-	apt-get purge -y --auto-remove wget; \
-# smoke test
+	pypy3 -m ensurepip --default-pip; \
 	pip --version; \
 	\
 	find /opt/pypy -depth \
@@ -140,7 +111,6 @@ RUN set -ex; \
 			\( -type d -a \( -name test -o -name tests \) \) \
 			-o \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' +; \
-	rm -f get-pip.py
+		\) -exec rm -rf '{}' +
 
 CMD ["pypy3"]

--- a/3.11/slim-bookworm/Dockerfile
+++ b/3.11/slim-bookworm/Dockerfile
@@ -105,6 +105,9 @@ RUN set -eux; \
 	\
 	pypy3 -m ensurepip --default-pip; \
 	pip --version; \
+# https://github.com/docker-library/python/issues/952
+# https://github.com/docker-library/python/issues/1023
+	pip install --disable-pip-version-check --no-cache-dir --no-compile 'wheel<0.46'; \
 	\
 	find /opt/pypy -depth \
 		\( \

--- a/3.11/windows/windowsservercore-1809/Dockerfile
+++ b/3.11/windows/windowsservercore-1809/Dockerfile
@@ -76,6 +76,11 @@ RUN $url = 'https://downloads.python.org/pypy/pypy3.11-v7.3.19-win64.zip'; \
 	Write-Host 'Verifying pip install ...'; \
 	pip --version; \
 	\
+	Write-Host 'Installing "wheel" (backwards compat) ...'; \
+# https://github.com/docker-library/python/issues/952
+# https://github.com/docker-library/python/issues/1023
+	pip install --disable-pip-version-check --no-cache-dir --no-compile 'wheel<0.46'; \
+	\
 	Write-Host 'Cleanup install ...'; \
 	Get-ChildItem \
 		-Path C:\pypy \

--- a/3.11/windows/windowsservercore-1809/Dockerfile
+++ b/3.11/windows/windowsservercore-1809/Dockerfile
@@ -70,46 +70,8 @@ RUN $url = 'https://downloads.python.org/pypy/pypy3.11-v7.3.19-win64.zip'; \
 	Write-Host 'Verifying install ("pypy --version") ...'; \
 	pypy --version; \
 	\
-	Write-Host 'Cleanup install ...'; \
-	Get-ChildItem \
-		-Path C:\pypy \
-		-Include @( 'test', 'tests' ) \
-		-Directory \
-		-Recurse \
-		| Remove-Item -Force -Recurse; \
-	Get-ChildItem \
-		-Path C:\pypy \
-		-Include @( '*.pyc', '*.pyo' ) \
-		-File \
-		-Recurse \
-		| Remove-Item -Force; \
-	\
-	Write-Host 'Complete.'
-
-# https://github.com/pypa/get-pip
-ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py
-ENV PYTHON_GET_PIP_SHA256 95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218
-
-RUN Write-Host ('Downloading get-pip.py ({0}) ...' -f $env:PYTHON_GET_PIP_URL); \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -Uri $env:PYTHON_GET_PIP_URL -OutFile 'get-pip.py'; \
-	Write-Host ('Verifying sha256 ({0}) ...' -f $env:PYTHON_GET_PIP_SHA256); \
-	if ((Get-FileHash 'get-pip.py' -Algorithm sha256).Hash -ne $env:PYTHON_GET_PIP_SHA256) { \
-		Write-Host 'FAILED!'; \
-		exit 1; \
-	}; \
-	\
-	$pipVersion = & pypy -c 'import ensurepip; print(ensurepip._PIP_VERSION)'; \
-	$setuptoolsVersion = & pypy -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)'; \
-	\
-	Write-Host ('Installing "pip == {0}", "setuptools == {1}" ...' -f $pipVersion, $setuptoolsVersion); \
-	pypy get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		('pip == {0}' -f $pipVersion) \
-		('setuptools == {0}' -f $setuptoolsVersion) \
-	; \
-	Remove-Item get-pip.py -Force; \
+	Write-Host 'Installing pip ...'; \
+	pypy -m ensurepip --default-pip; \
 	\
 	Write-Host 'Verifying pip install ...'; \
 	pip --version; \

--- a/3.11/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/3.11/windows/windowsservercore-ltsc2022/Dockerfile
@@ -76,6 +76,11 @@ RUN $url = 'https://downloads.python.org/pypy/pypy3.11-v7.3.19-win64.zip'; \
 	Write-Host 'Verifying pip install ...'; \
 	pip --version; \
 	\
+	Write-Host 'Installing "wheel" (backwards compat) ...'; \
+# https://github.com/docker-library/python/issues/952
+# https://github.com/docker-library/python/issues/1023
+	pip install --disable-pip-version-check --no-cache-dir --no-compile 'wheel<0.46'; \
+	\
 	Write-Host 'Cleanup install ...'; \
 	Get-ChildItem \
 		-Path C:\pypy \

--- a/3.11/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/3.11/windows/windowsservercore-ltsc2022/Dockerfile
@@ -70,46 +70,8 @@ RUN $url = 'https://downloads.python.org/pypy/pypy3.11-v7.3.19-win64.zip'; \
 	Write-Host 'Verifying install ("pypy --version") ...'; \
 	pypy --version; \
 	\
-	Write-Host 'Cleanup install ...'; \
-	Get-ChildItem \
-		-Path C:\pypy \
-		-Include @( 'test', 'tests' ) \
-		-Directory \
-		-Recurse \
-		| Remove-Item -Force -Recurse; \
-	Get-ChildItem \
-		-Path C:\pypy \
-		-Include @( '*.pyc', '*.pyo' ) \
-		-File \
-		-Recurse \
-		| Remove-Item -Force; \
-	\
-	Write-Host 'Complete.'
-
-# https://github.com/pypa/get-pip
-ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py
-ENV PYTHON_GET_PIP_SHA256 95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218
-
-RUN Write-Host ('Downloading get-pip.py ({0}) ...' -f $env:PYTHON_GET_PIP_URL); \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -Uri $env:PYTHON_GET_PIP_URL -OutFile 'get-pip.py'; \
-	Write-Host ('Verifying sha256 ({0}) ...' -f $env:PYTHON_GET_PIP_SHA256); \
-	if ((Get-FileHash 'get-pip.py' -Algorithm sha256).Hash -ne $env:PYTHON_GET_PIP_SHA256) { \
-		Write-Host 'FAILED!'; \
-		exit 1; \
-	}; \
-	\
-	$pipVersion = & pypy -c 'import ensurepip; print(ensurepip._PIP_VERSION)'; \
-	$setuptoolsVersion = & pypy -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)'; \
-	\
-	Write-Host ('Installing "pip == {0}", "setuptools == {1}" ...' -f $pipVersion, $setuptoolsVersion); \
-	pypy get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		('pip == {0}' -f $pipVersion) \
-		('setuptools == {0}' -f $setuptoolsVersion) \
-	; \
-	Remove-Item get-pip.py -Force; \
+	Write-Host 'Installing pip ...'; \
+	pypy -m ensurepip --default-pip; \
 	\
 	Write-Host 'Verifying pip install ...'; \
 	pip --version; \

--- a/3.11/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/3.11/windows/windowsservercore-ltsc2025/Dockerfile
@@ -76,6 +76,11 @@ RUN $url = 'https://downloads.python.org/pypy/pypy3.11-v7.3.19-win64.zip'; \
 	Write-Host 'Verifying pip install ...'; \
 	pip --version; \
 	\
+	Write-Host 'Installing "wheel" (backwards compat) ...'; \
+# https://github.com/docker-library/python/issues/952
+# https://github.com/docker-library/python/issues/1023
+	pip install --disable-pip-version-check --no-cache-dir --no-compile 'wheel<0.46'; \
+	\
 	Write-Host 'Cleanup install ...'; \
 	Get-ChildItem \
 		-Path C:\pypy \

--- a/3.11/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/3.11/windows/windowsservercore-ltsc2025/Dockerfile
@@ -70,46 +70,8 @@ RUN $url = 'https://downloads.python.org/pypy/pypy3.11-v7.3.19-win64.zip'; \
 	Write-Host 'Verifying install ("pypy --version") ...'; \
 	pypy --version; \
 	\
-	Write-Host 'Cleanup install ...'; \
-	Get-ChildItem \
-		-Path C:\pypy \
-		-Include @( 'test', 'tests' ) \
-		-Directory \
-		-Recurse \
-		| Remove-Item -Force -Recurse; \
-	Get-ChildItem \
-		-Path C:\pypy \
-		-Include @( '*.pyc', '*.pyo' ) \
-		-File \
-		-Recurse \
-		| Remove-Item -Force; \
-	\
-	Write-Host 'Complete.'
-
-# https://github.com/pypa/get-pip
-ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py
-ENV PYTHON_GET_PIP_SHA256 95c5ee602b2f3cc50ae053d716c3c89bea62c58568f64d7d25924d399b2d5218
-
-RUN Write-Host ('Downloading get-pip.py ({0}) ...' -f $env:PYTHON_GET_PIP_URL); \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -Uri $env:PYTHON_GET_PIP_URL -OutFile 'get-pip.py'; \
-	Write-Host ('Verifying sha256 ({0}) ...' -f $env:PYTHON_GET_PIP_SHA256); \
-	if ((Get-FileHash 'get-pip.py' -Algorithm sha256).Hash -ne $env:PYTHON_GET_PIP_SHA256) { \
-		Write-Host 'FAILED!'; \
-		exit 1; \
-	}; \
-	\
-	$pipVersion = & pypy -c 'import ensurepip; print(ensurepip._PIP_VERSION)'; \
-	$setuptoolsVersion = & pypy -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)'; \
-	\
-	Write-Host ('Installing "pip == {0}", "setuptools == {1}" ...' -f $pipVersion, $setuptoolsVersion); \
-	pypy get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		('pip == {0}' -f $pipVersion) \
-		('setuptools == {0}' -f $setuptoolsVersion) \
-	; \
-	Remove-Item get-pip.py -Force; \
+	Write-Host 'Installing pip ...'; \
+	pypy -m ensurepip --default-pip; \
 	\
 	Write-Host 'Verifying pip install ...'; \
 	pip --version; \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -169,40 +169,7 @@ RUN set -eux; \
 # smoke test again, to be sure
 	{{ cmd }} --version; \
 	\
-	find /opt/pypy -depth \
-		\( \
-			\( -type d -a \( -name test -o -name tests \) \) \
-			-o \
-			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' +
-
-# https://github.com/pypa/get-pip
-ENV PYTHON_GET_PIP_URL {{ ."get-pip".url }}
-ENV PYTHON_GET_PIP_SHA256 {{ ."get-pip".sha256 }}
-
-RUN set -ex; \
-{{ if is_slim then ( -}}
-	apt-get update; \
-	apt-get install -y --no-install-recommends wget; \
-	rm -rf /var/lib/apt/lists/*; \
-{{ ) else "" end -}}
-	\
-	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
-	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
-	\
-	pipVersion="$({{ cmd }} -c 'import ensurepip; print(ensurepip._PIP_VERSION)')"; \
-	setuptoolsVersion="$({{ cmd }} -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)')"; \
-	\
-	{{ cmd }} get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		"pip == $pipVersion" \
-		"setuptools == $setuptoolsVersion" \
-	; \
-{{ if is_slim then ( -}}
-	apt-get purge -y --auto-remove wget; \
-{{ ) else "" end -}}
-# smoke test
+	{{ cmd }} -m ensurepip --default-pip; \
 	pip --version; \
 	\
 	find /opt/pypy -depth \
@@ -210,7 +177,6 @@ RUN set -ex; \
 			\( -type d -a \( -name test -o -name tests \) \) \
 			-o \
 			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' +; \
-	rm -f get-pip.py
+		\) -exec rm -rf '{}' +
 
 CMD {{ [ cmd ] | @json }}

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -1,16 +1,9 @@
 {{
+	include "shared"
+	;
 	def is_slim:
 		env.variant
 		| startswith("slim-")
-	;
-	def is_3:
-		env.version
-		| startswith("3")
-	;
-	def minor:
-		env.version
-		| split(".")[1]
-		| tonumber
 	;
 	def lib_pypy:
 		if is_3 and minor >= 8 then
@@ -171,6 +164,11 @@ RUN set -eux; \
 	\
 	{{ cmd }} -m ensurepip --default-pip; \
 	pip --version; \
+{{ if is_3 and minor >= 12 then "" else ( -}}
+# https://github.com/docker-library/python/issues/952
+# https://github.com/docker-library/python/issues/1023
+	pip install --disable-pip-version-check --no-cache-dir --no-compile 'wheel<0.46'; \
+{{ ) end -}}
 	\
 	find /opt/pypy -depth \
 		\( \

--- a/Dockerfile-windows-servercore.template
+++ b/Dockerfile-windows-servercore.template
@@ -70,46 +70,8 @@ RUN $url = '{{ .arches["windows-amd64"].url }}'; \
 	Write-Host 'Verifying install ("pypy --version") ...'; \
 	pypy --version; \
 	\
-	Write-Host 'Cleanup install ...'; \
-	Get-ChildItem \
-		-Path C:\pypy \
-		-Include @( 'test', 'tests' ) \
-		-Directory \
-		-Recurse \
-		| Remove-Item -Force -Recurse; \
-	Get-ChildItem \
-		-Path C:\pypy \
-		-Include @( '*.pyc', '*.pyo' ) \
-		-File \
-		-Recurse \
-		| Remove-Item -Force; \
-	\
-	Write-Host 'Complete.'
-
-# https://github.com/pypa/get-pip
-ENV PYTHON_GET_PIP_URL {{ ."get-pip".url }}
-ENV PYTHON_GET_PIP_SHA256 {{ ."get-pip".sha256 }}
-
-RUN Write-Host ('Downloading get-pip.py ({0}) ...' -f $env:PYTHON_GET_PIP_URL); \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -Uri $env:PYTHON_GET_PIP_URL -OutFile 'get-pip.py'; \
-	Write-Host ('Verifying sha256 ({0}) ...' -f $env:PYTHON_GET_PIP_SHA256); \
-	if ((Get-FileHash 'get-pip.py' -Algorithm sha256).Hash -ne $env:PYTHON_GET_PIP_SHA256) { \
-		Write-Host 'FAILED!'; \
-		exit 1; \
-	}; \
-	\
-	$pipVersion = & pypy -c 'import ensurepip; print(ensurepip._PIP_VERSION)'; \
-	$setuptoolsVersion = & pypy -c 'import ensurepip; print(ensurepip._SETUPTOOLS_VERSION)'; \
-	\
-	Write-Host ('Installing "pip == {0}", "setuptools == {1}" ...' -f $pipVersion, $setuptoolsVersion); \
-	pypy get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		('pip == {0}' -f $pipVersion) \
-		('setuptools == {0}' -f $setuptoolsVersion) \
-	; \
-	Remove-Item get-pip.py -Force; \
+	Write-Host 'Installing pip ...'; \
+	pypy -m ensurepip --default-pip; \
 	\
 	Write-Host 'Verifying pip install ...'; \
 	pip --version; \

--- a/Dockerfile-windows-servercore.template
+++ b/Dockerfile-windows-servercore.template
@@ -1,4 +1,4 @@
-{{ def is_3: env.version | startswith("3") -}}
+{{ include "shared" -}}
 FROM mcr.microsoft.com/windows/{{ env.windowsVariant }}:{{ env.windowsRelease }}
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
@@ -76,6 +76,13 @@ RUN $url = '{{ .arches["windows-amd64"].url }}'; \
 	Write-Host 'Verifying pip install ...'; \
 	pip --version; \
 	\
+{{ if is_3 and minor >= 12 then "" else ( -}}
+	Write-Host 'Installing "wheel" (backwards compat) ...'; \
+# https://github.com/docker-library/python/issues/952
+# https://github.com/docker-library/python/issues/1023
+	pip install --disable-pip-version-check --no-cache-dir --no-compile 'wheel<0.46'; \
+	\
+{{ ) end -}}
 	Write-Host 'Cleanup install ...'; \
 	Get-ChildItem \
 		-Path C:\pypy \

--- a/shared.jq
+++ b/shared.jq
@@ -1,0 +1,9 @@
+def is_3:
+	env.version
+	| startswith("3")
+;
+def minor:
+	env.version
+	| split(".")[1]
+	| tonumber
+;


### PR DESCRIPTION
Instead of asking `ensurepip` which version of `pip` (and `setuptools`) to install via `get-pip.py`, just ask `ensurepip` to install them.