### PR TITLE
Update 3.11 to 7.3.21

### DIFF
--- a/2.7/bookworm/Dockerfile
+++ b/2.7/bookworm/Dockerfile
@@ -50,6 +50,9 @@ RUN set -eux; \
 	find /opt/pypy/lib* -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
 	\
+# delete a few (sometimes) problematic bundled libraries
+	rm -v /opt/pypy/lib/libtk*.so /opt/pypy/lib/libz.so*; \
+	\
 	ln -sv '/opt/pypy/bin/pypy' /usr/local/bin/; \
 	\
 # smoke test

--- a/2.7/slim-bookworm/Dockerfile
+++ b/2.7/slim-bookworm/Dockerfile
@@ -57,6 +57,9 @@ RUN set -eux; \
 	find /opt/pypy/lib* -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
 	\
+# delete a few (sometimes) problematic bundled libraries
+	rm -v /opt/pypy/lib/libtk*.so /opt/pypy/lib/libz.so*; \
+	\
 	ln -sv '/opt/pypy/bin/pypy' /usr/local/bin/; \
 	\
 # smoke test

--- a/2.7/slim-trixie/Dockerfile
+++ b/2.7/slim-trixie/Dockerfile
@@ -57,6 +57,9 @@ RUN set -eux; \
 	find /opt/pypy/lib* -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
 	\
+# delete a few (sometimes) problematic bundled libraries
+	rm -v /opt/pypy/lib/libtk*.so /opt/pypy/lib/libz.so*; \
+	\
 	ln -sv '/opt/pypy/bin/pypy' /usr/local/bin/; \
 	\
 # smoke test

--- a/2.7/trixie/Dockerfile
+++ b/2.7/trixie/Dockerfile
@@ -50,6 +50,9 @@ RUN set -eux; \
 	find /opt/pypy/lib* -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
 	\
+# delete a few (sometimes) problematic bundled libraries
+	rm -v /opt/pypy/lib/libtk*.so /opt/pypy/lib/libz.so*; \
+	\
 	ln -sv '/opt/pypy/bin/pypy' /usr/local/bin/; \
 	\
 # smoke test

--- a/3.11/bookworm/Dockerfile
+++ b/3.11/bookworm/Dockerfile
@@ -22,24 +22,24 @@ ENV LANG C.UTF-8
 # ensure local pypy3 is preferred over distribution pypy3
 ENV PATH /opt/pypy/bin:$PATH
 
-# Python 3.11.13
-ENV PYPY_VERSION 7.3.20
+# Python 3.11.15
+ENV PYPY_VERSION 7.3.21
 
 RUN set -eux; \
 	\
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "${dpkgArch##*-}" in \
 		'amd64') \
-			url='https://downloads.python.org/pypy/pypy3.11-v7.3.20-linux64.tar.bz2'; \
-			sha256='1410db3a7ae47603e2b7cbfd7ff6390b891b2e041c9eb4f1599f333677bccb3e'; \
+			url='https://downloads.python.org/pypy/pypy3.11-v7.3.21-linux64.tar.bz2'; \
+			sha256='43f27af8ee6673932493f2696ab407321cbf79dbed94c03d8b39e603f8f5f765'; \
 			;; \
 		'arm64') \
-			url='https://downloads.python.org/pypy/pypy3.11-v7.3.20-aarch64.tar.bz2'; \
-			sha256='9347fe691a07fd9df17a1b186554fb9d9e6210178ffef19520a579ce1f9eb741'; \
+			url='https://downloads.python.org/pypy/pypy3.11-v7.3.21-aarch64.tar.bz2'; \
+			sha256='6141f5c64dd96faf87e0a3f7f362521eadd26d5e3f851f90fc386a72208f8c18'; \
 			;; \
 		'i386') \
-			url='https://downloads.python.org/pypy/pypy3.11-v7.3.20-linux32.tar.bz2'; \
-			sha256='d08ce15dd61e9ace5e010b047104f0137110a258184e448ea8239472f10cf99b'; \
+			url='https://downloads.python.org/pypy/pypy3.11-v7.3.21-linux32.tar.bz2'; \
+			sha256='0c449ff3f20589e331f163807a0200a9bf5dd375c95f513a0f60bf7524795f02'; \
 			;; \
 		*) echo >&2 "error: current architecture ($dpkgArch) does not have a corresponding PyPy $PYPY_VERSION binary release"; exit 1 ;; \
 	esac; \
@@ -59,29 +59,36 @@ RUN set -eux; \
 	find /opt/pypy/lib* -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
 	\
+# delete a few (sometimes) problematic bundled libraries
+	rm -v /opt/pypy/lib/libtk*.so /opt/pypy/lib/libz.so*; \
+	\
 	ln -sv '/opt/pypy/bin/pypy3' /usr/local/bin/; \
 	\
 # smoke test
 	pypy3 --version; \
 	\
+# rebuild several cffi modules for compatibility
 	cd /opt/pypy/lib/pypy3.11; \
-# on pypy3, rebuild gdbm ffi bits for compatibility with Debian Stretch+
 	if [ -f _gdbm_build.py ]; then \
 		pypy3 _gdbm_build.py; \
 	fi; \
-# https://github.com/docker-library/pypy/issues/24#issuecomment-409408657
 	if [ -f _ssl_build.py ]; then \
+# https://github.com/docker-library/pypy/issues/24#issuecomment-409408657
 		pypy3 _ssl_build.py; \
 	fi; \
-# https://github.com/docker-library/pypy/issues/42
 	if [ -f _lzma_build.py ]; then \
+# https://github.com/docker-library/pypy/issues/42
 		pypy3 _lzma_build.py; \
 	fi; \
-# https://github.com/docker-library/pypy/issues/68
 	if [ -f _sqlite3_build.py ]; then \
+# https://github.com/docker-library/pypy/issues/68
 		pypy3 _sqlite3_build.py; \
 	fi; \
-# TODO rebuild other cffi modules here too? (other _*_build.py files)
+	if [ -f _tkinter/tklib_build.py ]; then \
+		apt-get install -y --no-install-recommends tk-dev; \
+		pypy3 _tkinter/tklib_build.py; \
+	fi; \
+# TODO rebuild other cffi modules here too? (other _*_build.py files; see https://github.com/pypy/pypy/blob/0f013f041fff7fb9a23b22dae8437e82beb6a279/lib_pypy/pypy_tools/build_cffi_imports.py#L25-L40)
 	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \

--- a/3.11/slim-bookworm/Dockerfile
+++ b/3.11/slim-bookworm/Dockerfile
@@ -18,24 +18,24 @@ ENV LANG C.UTF-8
 # ensure local pypy3 is preferred over distribution pypy3
 ENV PATH /opt/pypy/bin:$PATH
 
-# Python 3.11.13
-ENV PYPY_VERSION 7.3.20
+# Python 3.11.15
+ENV PYPY_VERSION 7.3.21
 
 RUN set -eux; \
 	\
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "${dpkgArch##*-}" in \
 		'amd64') \
-			url='https://downloads.python.org/pypy/pypy3.11-v7.3.20-linux64.tar.bz2'; \
-			sha256='1410db3a7ae47603e2b7cbfd7ff6390b891b2e041c9eb4f1599f333677bccb3e'; \
+			url='https://downloads.python.org/pypy/pypy3.11-v7.3.21-linux64.tar.bz2'; \
+			sha256='43f27af8ee6673932493f2696ab407321cbf79dbed94c03d8b39e603f8f5f765'; \
 			;; \
 		'arm64') \
-			url='https://downloads.python.org/pypy/pypy3.11-v7.3.20-aarch64.tar.bz2'; \
-			sha256='9347fe691a07fd9df17a1b186554fb9d9e6210178ffef19520a579ce1f9eb741'; \
+			url='https://downloads.python.org/pypy/pypy3.11-v7.3.21-aarch64.tar.bz2'; \
+			sha256='6141f5c64dd96faf87e0a3f7f362521eadd26d5e3f851f90fc386a72208f8c18'; \
 			;; \
 		'i386') \
-			url='https://downloads.python.org/pypy/pypy3.11-v7.3.20-linux32.tar.bz2'; \
-			sha256='d08ce15dd61e9ace5e010b047104f0137110a258184e448ea8239472f10cf99b'; \
+			url='https://downloads.python.org/pypy/pypy3.11-v7.3.21-linux32.tar.bz2'; \
+			sha256='0c449ff3f20589e331f163807a0200a9bf5dd375c95f513a0f60bf7524795f02'; \
 			;; \
 		*) echo >&2 "error: current architecture ($dpkgArch) does not have a corresponding PyPy $PYPY_VERSION binary release"; exit 1 ;; \
 	esac; \
@@ -57,33 +57,40 @@ RUN set -eux; \
 	find /opt/pypy/lib* -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
 	\
+# delete a few (sometimes) problematic bundled libraries
+	rm -v /opt/pypy/lib/libtk*.so /opt/pypy/lib/libz.so*; \
+	\
 	ln -sv '/opt/pypy/bin/pypy3' /usr/local/bin/; \
 	\
 # smoke test
 	pypy3 --version; \
 	\
+# rebuild several cffi modules for compatibility
 	cd /opt/pypy/lib/pypy3.11; \
-# on pypy3, rebuild gdbm ffi bits for compatibility with Debian Stretch+
 	if [ -f _gdbm_build.py ]; then \
 		apt-get install -y --no-install-recommends gcc libc6-dev libgdbm-dev; \
 		pypy3 _gdbm_build.py; \
 	fi; \
-# https://github.com/docker-library/pypy/issues/24#issuecomment-409408657
 	if [ -f _ssl_build.py ]; then \
+# https://github.com/docker-library/pypy/issues/24#issuecomment-409408657
 		apt-get install -y --no-install-recommends gcc libc6-dev libssl-dev; \
 		pypy3 _ssl_build.py; \
 	fi; \
-# https://github.com/docker-library/pypy/issues/42
 	if [ -f _lzma_build.py ]; then \
+# https://github.com/docker-library/pypy/issues/42
 		apt-get install -y --no-install-recommends gcc libc6-dev liblzma-dev; \
 		pypy3 _lzma_build.py; \
 	fi; \
-# https://github.com/docker-library/pypy/issues/68
 	if [ -f _sqlite3_build.py ]; then \
+# https://github.com/docker-library/pypy/issues/68
 		apt-get install -y --no-install-recommends gcc libc6-dev libsqlite3-dev; \
 		pypy3 _sqlite3_build.py; \
 	fi; \
-# TODO rebuild other cffi modules here too? (other _*_build.py files)
+	if [ -f _tkinter/tklib_build.py ]; then \
+		apt-get install -y --no-install-recommends gcc libc6-dev tk-dev; \
+		pypy3 _tkinter/tklib_build.py; \
+	fi; \
+# TODO rebuild other cffi modules here too? (other _*_build.py files; see https://github.com/pypy/pypy/blob/0f013f041fff7fb9a23b22dae8437e82beb6a279/lib_pypy/pypy_tools/build_cffi_imports.py#L25-L40)
 	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \

--- a/3.11/slim-trixie/Dockerfile
+++ b/3.11/slim-trixie/Dockerfile
@@ -18,24 +18,24 @@ ENV LANG C.UTF-8
 # ensure local pypy3 is preferred over distribution pypy3
 ENV PATH /opt/pypy/bin:$PATH
 
-# Python 3.11.13
-ENV PYPY_VERSION 7.3.20
+# Python 3.11.15
+ENV PYPY_VERSION 7.3.21
 
 RUN set -eux; \
 	\
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "${dpkgArch##*-}" in \
 		'amd64') \
-			url='https://downloads.python.org/pypy/pypy3.11-v7.3.20-linux64.tar.bz2'; \
-			sha256='1410db3a7ae47603e2b7cbfd7ff6390b891b2e041c9eb4f1599f333677bccb3e'; \
+			url='https://downloads.python.org/pypy/pypy3.11-v7.3.21-linux64.tar.bz2'; \
+			sha256='43f27af8ee6673932493f2696ab407321cbf79dbed94c03d8b39e603f8f5f765'; \
 			;; \
 		'arm64') \
-			url='https://downloads.python.org/pypy/pypy3.11-v7.3.20-aarch64.tar.bz2'; \
-			sha256='9347fe691a07fd9df17a1b186554fb9d9e6210178ffef19520a579ce1f9eb741'; \
+			url='https://downloads.python.org/pypy/pypy3.11-v7.3.21-aarch64.tar.bz2'; \
+			sha256='6141f5c64dd96faf87e0a3f7f362521eadd26d5e3f851f90fc386a72208f8c18'; \
 			;; \
 		'i386') \
-			url='https://downloads.python.org/pypy/pypy3.11-v7.3.20-linux32.tar.bz2'; \
-			sha256='d08ce15dd61e9ace5e010b047104f0137110a258184e448ea8239472f10cf99b'; \
+			url='https://downloads.python.org/pypy/pypy3.11-v7.3.21-linux32.tar.bz2'; \
+			sha256='0c449ff3f20589e331f163807a0200a9bf5dd375c95f513a0f60bf7524795f02'; \
 			;; \
 		*) echo >&2 "error: current architecture ($dpkgArch) does not have a corresponding PyPy $PYPY_VERSION binary release"; exit 1 ;; \
 	esac; \
@@ -57,33 +57,40 @@ RUN set -eux; \
 	find /opt/pypy/lib* -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
 	\
+# delete a few (sometimes) problematic bundled libraries
+	rm -v /opt/pypy/lib/libtk*.so /opt/pypy/lib/libz.so*; \
+	\
 	ln -sv '/opt/pypy/bin/pypy3' /usr/local/bin/; \
 	\
 # smoke test
 	pypy3 --version; \
 	\
+# rebuild several cffi modules for compatibility
 	cd /opt/pypy/lib/pypy3.11; \
-# on pypy3, rebuild gdbm ffi bits for compatibility with Debian Stretch+
 	if [ -f _gdbm_build.py ]; then \
 		apt-get install -y --no-install-recommends gcc libc6-dev libgdbm-dev; \
 		pypy3 _gdbm_build.py; \
 	fi; \
-# https://github.com/docker-library/pypy/issues/24#issuecomment-409408657
 	if [ -f _ssl_build.py ]; then \
+# https://github.com/docker-library/pypy/issues/24#issuecomment-409408657
 		apt-get install -y --no-install-recommends gcc libc6-dev libssl-dev; \
 		pypy3 _ssl_build.py; \
 	fi; \
-# https://github.com/docker-library/pypy/issues/42
 	if [ -f _lzma_build.py ]; then \
+# https://github.com/docker-library/pypy/issues/42
 		apt-get install -y --no-install-recommends gcc libc6-dev liblzma-dev; \
 		pypy3 _lzma_build.py; \
 	fi; \
-# https://github.com/docker-library/pypy/issues/68
 	if [ -f _sqlite3_build.py ]; then \
+# https://github.com/docker-library/pypy/issues/68
 		apt-get install -y --no-install-recommends gcc libc6-dev libsqlite3-dev; \
 		pypy3 _sqlite3_build.py; \
 	fi; \
-# TODO rebuild other cffi modules here too? (other _*_build.py files)
+	if [ -f _tkinter/tklib_build.py ]; then \
+		apt-get install -y --no-install-recommends gcc libc6-dev tk-dev; \
+		pypy3 _tkinter/tklib_build.py; \
+	fi; \
+# TODO rebuild other cffi modules here too? (other _*_build.py files; see https://github.com/pypy/pypy/blob/0f013f041fff7fb9a23b22dae8437e82beb6a279/lib_pypy/pypy_tools/build_cffi_imports.py#L25-L40)
 	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \

--- a/3.11/trixie/Dockerfile
+++ b/3.11/trixie/Dockerfile
@@ -22,24 +22,24 @@ ENV LANG C.UTF-8
 # ensure local pypy3 is preferred over distribution pypy3
 ENV PATH /opt/pypy/bin:$PATH
 
-# Python 3.11.13
-ENV PYPY_VERSION 7.3.20
+# Python 3.11.15
+ENV PYPY_VERSION 7.3.21
 
 RUN set -eux; \
 	\
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "${dpkgArch##*-}" in \
 		'amd64') \
-			url='https://downloads.python.org/pypy/pypy3.11-v7.3.20-linux64.tar.bz2'; \
-			sha256='1410db3a7ae47603e2b7cbfd7ff6390b891b2e041c9eb4f1599f333677bccb3e'; \
+			url='https://downloads.python.org/pypy/pypy3.11-v7.3.21-linux64.tar.bz2'; \
+			sha256='43f27af8ee6673932493f2696ab407321cbf79dbed94c03d8b39e603f8f5f765'; \
 			;; \
 		'arm64') \
-			url='https://downloads.python.org/pypy/pypy3.11-v7.3.20-aarch64.tar.bz2'; \
-			sha256='9347fe691a07fd9df17a1b186554fb9d9e6210178ffef19520a579ce1f9eb741'; \
+			url='https://downloads.python.org/pypy/pypy3.11-v7.3.21-aarch64.tar.bz2'; \
+			sha256='6141f5c64dd96faf87e0a3f7f362521eadd26d5e3f851f90fc386a72208f8c18'; \
 			;; \
 		'i386') \
-			url='https://downloads.python.org/pypy/pypy3.11-v7.3.20-linux32.tar.bz2'; \
-			sha256='d08ce15dd61e9ace5e010b047104f0137110a258184e448ea8239472f10cf99b'; \
+			url='https://downloads.python.org/pypy/pypy3.11-v7.3.21-linux32.tar.bz2'; \
+			sha256='0c449ff3f20589e331f163807a0200a9bf5dd375c95f513a0f60bf7524795f02'; \
 			;; \
 		*) echo >&2 "error: current architecture ($dpkgArch) does not have a corresponding PyPy $PYPY_VERSION binary release"; exit 1 ;; \
 	esac; \
@@ -59,29 +59,36 @@ RUN set -eux; \
 	find /opt/pypy/lib* -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
 	\
+# delete a few (sometimes) problematic bundled libraries
+	rm -v /opt/pypy/lib/libtk*.so /opt/pypy/lib/libz.so*; \
+	\
 	ln -sv '/opt/pypy/bin/pypy3' /usr/local/bin/; \
 	\
 # smoke test
 	pypy3 --version; \
 	\
+# rebuild several cffi modules for compatibility
 	cd /opt/pypy/lib/pypy3.11; \
-# on pypy3, rebuild gdbm ffi bits for compatibility with Debian Stretch+
 	if [ -f _gdbm_build.py ]; then \
 		pypy3 _gdbm_build.py; \
 	fi; \
-# https://github.com/docker-library/pypy/issues/24#issuecomment-409408657
 	if [ -f _ssl_build.py ]; then \
+# https://github.com/docker-library/pypy/issues/24#issuecomment-409408657
 		pypy3 _ssl_build.py; \
 	fi; \
-# https://github.com/docker-library/pypy/issues/42
 	if [ -f _lzma_build.py ]; then \
+# https://github.com/docker-library/pypy/issues/42
 		pypy3 _lzma_build.py; \
 	fi; \
-# https://github.com/docker-library/pypy/issues/68
 	if [ -f _sqlite3_build.py ]; then \
+# https://github.com/docker-library/pypy/issues/68
 		pypy3 _sqlite3_build.py; \
 	fi; \
-# TODO rebuild other cffi modules here too? (other _*_build.py files)
+	if [ -f _tkinter/tklib_build.py ]; then \
+		apt-get install -y --no-install-recommends tk-dev; \
+		pypy3 _tkinter/tklib_build.py; \
+	fi; \
+# TODO rebuild other cffi modules here too? (other _*_build.py files; see https://github.com/pypy/pypy/blob/0f013f041fff7fb9a23b22dae8437e82beb6a279/lib_pypy/pypy_tools/build_cffi_imports.py#L25-L40)
 	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \

--- a/3.11/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/3.11/windows/windowsservercore-ltsc2022/Dockerfile
@@ -44,14 +44,14 @@ RUN $url = 'https://download.microsoft.com/download/6/A/A/6AA4EDFF-645B-48C5-81C
 	\
 	Write-Host 'Complete.'
 
-# Python 3.11.13
-ENV PYPY_VERSION 7.3.20
+# Python 3.11.15
+ENV PYPY_VERSION 7.3.21
 
-RUN $url = 'https://downloads.python.org/pypy/pypy3.11-v7.3.20-win64.zip'; \
+RUN $url = 'https://downloads.python.org/pypy/pypy3.11-v7.3.21-win64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	Invoke-WebRequest -Uri $url -OutFile 'pypy.zip'; \
 	\
-	$sha256 = 'a8d36f6ceb1d9be6cf24a73b0ba103e7567e396b2f7a33426b05e4a06330755b'; \
+	$sha256 = 'a1a2b069533b838f465157025e58933199f311f5f3f58549ccaf9872ee90fa53'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash pypy.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \
@@ -65,7 +65,7 @@ RUN $url = 'https://downloads.python.org/pypy/pypy3.11-v7.3.20-win64.zip'; \
 	Remove-Item pypy.zip -Force; \
 	\
 	Write-Host 'Renaming ...'; \
-	Rename-Item -Path C:\pypy3.11-v7.3.20-win64 -NewName C:\pypy; \
+	Rename-Item -Path C:\pypy3.11-v7.3.21-win64 -NewName C:\pypy; \
 	\
 	Write-Host 'Verifying install ("pypy --version") ...'; \
 	pypy --version; \

--- a/3.11/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/3.11/windows/windowsservercore-ltsc2025/Dockerfile
@@ -44,14 +44,14 @@ RUN $url = 'https://download.microsoft.com/download/6/A/A/6AA4EDFF-645B-48C5-81C
 	\
 	Write-Host 'Complete.'
 
-# Python 3.11.13
-ENV PYPY_VERSION 7.3.20
+# Python 3.11.15
+ENV PYPY_VERSION 7.3.21
 
-RUN $url = 'https://downloads.python.org/pypy/pypy3.11-v7.3.20-win64.zip'; \
+RUN $url = 'https://downloads.python.org/pypy/pypy3.11-v7.3.21-win64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	Invoke-WebRequest -Uri $url -OutFile 'pypy.zip'; \
 	\
-	$sha256 = 'a8d36f6ceb1d9be6cf24a73b0ba103e7567e396b2f7a33426b05e4a06330755b'; \
+	$sha256 = 'a1a2b069533b838f465157025e58933199f311f5f3f58549ccaf9872ee90fa53'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash pypy.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \
@@ -65,7 +65,7 @@ RUN $url = 'https://downloads.python.org/pypy/pypy3.11-v7.3.20-win64.zip'; \
 	Remove-Item pypy.zip -Force; \
 	\
 	Write-Host 'Renaming ...'; \
-	Rename-Item -Path C:\pypy3.11-v7.3.20-win64 -NewName C:\pypy; \
+	Rename-Item -Path C:\pypy3.11-v7.3.21-win64 -NewName C:\pypy; \
 	\
 	Write-Host 'Verifying install ("pypy --version") ...'; \
 	pypy --version; \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -116,17 +116,20 @@ RUN set -eux; \
 	find /opt/pypy/lib* -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' +; \
 	rm pypy.tar.bz2; \
 	\
+# delete a few (sometimes) problematic bundled libraries
+	rm -v /opt/pypy/lib/libtk*.so /opt/pypy/lib/libz.so*; \
+	\
 	ln -sv {{ "/opt/pypy/bin/" + cmd | @sh }} /usr/local/bin/; \
 	\
 # smoke test
 	{{ cmd }} --version; \
 	\
 {{ if is_3 then ( -}}
+# rebuild several cffi modules for compatibility
 	cd {{ lib_pypy }}; \
 {{
 	[
 		{
-			comment: "on pypy3, rebuild gdbm ffi bits for compatibility with Debian Stretch+",
 			file: "_gdbm_build.py",
 			deps: "libgdbm-dev",
 		},
@@ -145,18 +148,33 @@ RUN set -eux; \
 			file: "_sqlite3_build.py",
 			deps: "libsqlite3-dev",
 		},
+		{
+			file: "_tkinter/tklib_build.py",
+			deps: "tk-dev",
+		},
 		empty # trailing comma hack
 	] | map(
 -}}
-# {{ .comment }}
 	if [ -f {{ .file }} ]; then \
-{{ if is_slim then ( -}}
-		apt-get install -y --no-install-recommends gcc libc6-dev {{ .deps }}; \
+{{ if .comment then ( -}}
+# {{ .comment }}
+{{ ) else "" end -}}
+{{
+	(
+		if is_slim then
+			"gcc libc6-dev " + .deps
+		elif .deps == "tk-dev" then
+			.deps
+		else "" end
+	) as $install
+	| if $install != "" then
+( -}}
+		apt-get install -y --no-install-recommends {{ $install }}; \
 {{ ) else "" end -}}
 		{{ cmd }} {{ .file }}; \
 	fi; \
 {{ ) | join("") -}}
-# TODO rebuild other cffi modules here too? (other _*_build.py files)
+# TODO rebuild other cffi modules here too? (other _*_build.py files; see https://github.com/pypy/pypy/blob/0f013f041fff7fb9a23b22dae8437e82beb6a279/lib_pypy/pypy_tools/build_cffi_imports.py#L25-L40)
 	\
 {{ ) else "" end -}}
 	apt-mark auto '.*' > /dev/null; \

--- a/versions.json
+++ b/versions.json
@@ -48,28 +48,28 @@
   "3.11": {
     "arches": {
       "amd64": {
-        "sha256": "1410db3a7ae47603e2b7cbfd7ff6390b891b2e041c9eb4f1599f333677bccb3e",
-        "url": "https://downloads.python.org/pypy/pypy3.11-v7.3.20-linux64.tar.bz2"
+        "sha256": "43f27af8ee6673932493f2696ab407321cbf79dbed94c03d8b39e603f8f5f765",
+        "url": "https://downloads.python.org/pypy/pypy3.11-v7.3.21-linux64.tar.bz2"
       },
       "arm64v8": {
-        "sha256": "9347fe691a07fd9df17a1b186554fb9d9e6210178ffef19520a579ce1f9eb741",
-        "url": "https://downloads.python.org/pypy/pypy3.11-v7.3.20-aarch64.tar.bz2"
+        "sha256": "6141f5c64dd96faf87e0a3f7f362521eadd26d5e3f851f90fc386a72208f8c18",
+        "url": "https://downloads.python.org/pypy/pypy3.11-v7.3.21-aarch64.tar.bz2"
       },
       "darwin-": {
-        "sha256": "84a48e09c97f57df62cc9f01b7a6d8c3e306b6270671d871aa8ab8c06945940d",
-        "url": "https://downloads.python.org/pypy/pypy3.11-v7.3.20-macos_arm64.tar.bz2"
+        "sha256": "a43f97ff9f6016aac09ee75eb626d806e8ad865608e7d8bc4d3c2fc37c2b4799",
+        "url": "https://downloads.python.org/pypy/pypy3.11-v7.3.21-macos_arm64.tar.bz2"
       },
       "darwin-amd64": {
-        "sha256": "bb3ae80cf5fca5044af2e42933e7692c7c5e76a828ce0eb6404a5d5da83b313c",
-        "url": "https://downloads.python.org/pypy/pypy3.11-v7.3.20-macos_x86_64.tar.bz2"
+        "sha256": "60dfb37dda85d548cd6a4d7bdb12ff26e19162042001b741fd9b6a8ecee802a6",
+        "url": "https://downloads.python.org/pypy/pypy3.11-v7.3.21-macos_x86_64.tar.bz2"
       },
       "i386": {
-        "sha256": "d08ce15dd61e9ace5e010b047104f0137110a258184e448ea8239472f10cf99b",
-        "url": "https://downloads.python.org/pypy/pypy3.11-v7.3.20-linux32.tar.bz2"
+        "sha256": "0c449ff3f20589e331f163807a0200a9bf5dd375c95f513a0f60bf7524795f02",
+        "url": "https://downloads.python.org/pypy/pypy3.11-v7.3.21-linux32.tar.bz2"
       },
       "windows-amd64": {
-        "sha256": "a8d36f6ceb1d9be6cf24a73b0ba103e7567e396b2f7a33426b05e4a06330755b",
-        "url": "https://downloads.python.org/pypy/pypy3.11-v7.3.20-win64.zip"
+        "sha256": "a1a2b069533b838f465157025e58933199f311f5f3f58549ccaf9872ee90fa53",
+        "url": "https://downloads.python.org/pypy/pypy3.11-v7.3.21-win64.zip"
       }
     },
     "get-pip": {
@@ -79,7 +79,7 @@
     },
     "python": {
       "major": "3.11",
-      "version": "3.11.13"
+      "version": "3.11.15"
     },
     "variants": [
       "trixie",
@@ -89,6 +89,6 @@
       "windows/windowsservercore-ltsc2025",
       "windows/windowsservercore-ltsc2022"
     ],
-    "version": "7.3.20"
+    "version": "7.3.21"
   }
 }


### PR DESCRIPTION
Including (re-)building tkinter from source:

`/opt/pypy/lib/pypy3.11/_tkinter/tklib_cffi.pypy311-pp73-x86_64-linux-gnu.so: /opt/pypy/lib/pypy3.11/_tkinter/../.././libz.so.1: version 'ZLIB_1.2.9' not found (required by /lib/x86_64-linux-gnu/libpng16.so.16)`